### PR TITLE
clean up handlers to avoid leaking memory

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,11 @@
       var pos = registeredComponents.indexOf(this);
       if( pos>-1) {
         var fn = handlers[pos];
+
         if (fn) {
+          // clean up so we don't leak memory
+          handlers.splice(pos, 1);
+          registeredComponents.splice(pos, 1);
           document.removeEventListener("mousedown", fn);
           document.removeEventListener("touchstart", fn);
         }


### PR DESCRIPTION
Since every component that uses this mixin will add to the module state when it mounts, we end up leaking memory. We Remove the components and event handlers from their respective arrays when the components unmount to avoid this.