### PR TITLE
Check the top most node to see if it is inside or has class

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@
           // a layered approach, too, but that requires going back to
           // thinking in terms of Dom node nesting, running counter
           // to React's "you shouldn't care about the DOM" philosophy.
-          while(source.parentNode) {
+          while(source) {
             found = (source === localNode || source.classList.contains(IGNORE_CLASS));
             if(found) return;
             source = source.parentNode;


### PR DESCRIPTION
There is a bug when iterating upwards -- if we stop checking when the `source.parentNode` is undefined, we miss the last `source`. At least for the `IGNORE_CLASS`, this is a bug. I think it's a bug for the regular check too.