### PR TITLE
using the updated way to get the dom node on react

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@
           }
           eventHandler(evt);
         }
-      }(this.getDOMNode(), this.handleClickOutside));
+      }(React.findDOMNode(this), this.handleClickOutside));
 
       var pos = registeredComponents.length;
       registeredComponents.push(this);


### PR DESCRIPTION
The 'this.getDOMNode()' is deprecated and has been replaced with 'React.findDOMNode()'.

This point is also a impeditive to use it with the ES6 component that already don't has the getDOMNode.

I did a CodePen in onder to test it at least manually:
http://codepen.io/willgm/pen/oXPaov