### PR TITLE
Checks for classList existence before proceeding

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@
           // thinking in terms of Dom node nesting, running counter
           // to React's "you shouldn't care about the DOM" philosophy.
           while(source.parentNode) {
-            found = (source === localNode || source.classList.contains(IGNORE_CLASS));
+            found = (source === localNode || (source.classList && source.classList.contains(IGNORE_CLASS)));
             if(found) return;
             source = source.parentNode;
           }


### PR DESCRIPTION
In Safari, SVGElements do not have `classList` on them, so this component errors.  This is just a simple fix to not error out.