### PR TITLE
Added ability to listen to the click event 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When using this mixin, a component has two functions that can be used to explici
 
 - `enableOnClickOutside()` - Enables outside click listening by setting up the event listening bindings.
 - `disableOnClickOutside()` - Disables outside click listening by explicitly removing the event listening bindings.
- 
+
 In addition, you can create a component that uses this mixin such that it has the code set up and ready to go, but not listening for outside click events until you explicitly issue its `enableOnClickOutside()`, by passing in a properly called `disableOnClickOutside`:
 
 ```
@@ -86,3 +86,8 @@ var Container = React.createClass({
 If you want the mixin to ignore certain elements, then add the class `ignore-react-onclickoutside` to that element and the callback won't be invoked when the click happens inside elements with that class.
 
 For bugs and enhancements hit up https://github.com/Pomax/react-onclickoutside/issues
+
+## Listening to the 'click' event instead of mousedown and touchstart
+
+By default, this mixin will call handleClickOutside() when either the mousedown or touchstart DOM events are fired.
+To listen instead to the 'click' event, set 'useClickEvent' property on your component to true

--- a/index.js
+++ b/index.js
@@ -104,8 +104,16 @@
      */
     enableOnClickOutside: function() {
       var fn = this.__outsideClickHandler;
-      document.addEventListener("mousedown", fn);
-      document.addEventListener("touchstart", fn);
+
+      // if there is a truthy useClickEvent property for this component,
+      // listen to the click event instead of mousedown and touchstart
+      if(this.props.useClickEvent) {
+        document.addEventListener("click", fn);
+      } else {
+        document.addEventListener("mousedown", fn);
+        document.addEventListener("touchstart", fn);
+      }
+
     },
 
     /**
@@ -114,8 +122,12 @@
      */
     disableOnClickOutside: function(fn) {
       var fn = this.__outsideClickHandler;
-      document.removeEventListener("mousedown", fn);
-      document.removeEventListener("touchstart", fn);
+      if(this.props.useClickEvent) {
+        document.removeEventListener("click", fn);
+      } else {
+        document.removeEventListener("mousedown", fn);
+        document.removeEventListener("touchstart", fn);
+      }
     }
   };
 


### PR DESCRIPTION
I added the ability to listen to the click event instead of touchstart and mousedown by setting the useClickEvent property to true on your component.

There might be a cleaner way of implementing this.