### PR TITLE
fix event bubbling up

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@
 
       var fn = this.__outsideClickHandler = (function(localNode, eventHandler) {
         return function(evt) {
+          evt.stopPropagation();
           var source = evt.target;
           var found = false;
           // If source=local then this event came from "somewhere"


### PR DESCRIPTION
We will manually traverse up in the dom tree, so stop event bubbling up with `Event.stopPropagation()`