### PR TITLE
Allow `disableOnClickOutside` as a state variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@
 
       // If there is a truthy disableOnClickOutside property for this
       // component, don't immediately start listening for outside events.
-      if (!this.props.disableOnClickOutside) {
+      if (!this.props.disableOnClickOutside || !this.state.disableOnClickOutside) {
         this.enableOnClickOutside();
       }
     },


### PR DESCRIPTION
Allowing `disableOnClickOutside` in state, so the parent component don't need to know about the inner mechanics of the component.

This can be used together with enableOnClickOutside/disableOnClickOutside if the whole component isn't part of the callout/dialog. (Which probably isn't good style in general, but sometimes you do what you got to do.