### PR TITLE
Revert "use stopImmediatePropagation instead of stopPropagation"

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,11 +58,7 @@
 
       var fn = this.__outsideClickHandler = (function(localNode, eventHandler) {
         return function(evt) {
-          if (evt.stopImmediatePropagation) {
-            evt.stopImmediatePropagation();
-          } else {
-            evt.stopPropagation();
-          }
+          evt.stopPropagation();
           var source = evt.target;
           var found = false;
           // If source=local then this event came from "somewhere"


### PR DESCRIPTION
Reverts Pomax/react-onclickoutside#36 based on https://github.com/Pomax/react-onclickoutside/issues/35#issuecomment-147157982 and https://github.com/Pomax/react-onclickoutside/issues/40