### PR TITLE
Support changing event type to listen to

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,6 @@ var Component = React.createClass({
 });
 ```
 
-## Listen for mouse or touch release events
-
-By default, this mixin listens to mouse and touch press events. To instead listen for mouse and touch releases, set one or both of the props on your component called `outsideMouseEventType` and `outsideTouchEventType`.
-
-```
-  ...
-  getDefaultProps: function () {
-    return {
-      ...,
-      outsideMouseEventType: 'mouseup'
-    };
-  },
-  ...
-```
-
 ## Regulate whether or not to listen for outside clicks
 
 When using this mixin, a component has two functions that can be used to explicitly listen for, or do nothing with, outside clicks
@@ -94,6 +79,22 @@ var Container = React.createClass({
     return <Component disableOnClickOutside={true} />
   }
 });
+```
+
+## Listen for mouse or touch release events
+
+By default, this mixin listens to mouse and touch press events. To instead listen for mouse and touch releases, you should pass that as an option into `enableOnClickOutside()`.
+
+```
+  getDefaultProps: function() {
+    return {
+      disableOnClickOutside: true
+    };
+  },
+
+  componentDidMount: function() {
+    this.enableOnClickOutside({ mouseup: true });
+  },
 ```
 
 ## Marking elements as "skip over this one" during the event loop

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ var Component = React.createClass({
 });
 ```
 
+## Listen for mouse or touch release events
+
+By default, this mixin listens to mouse and touch press events. To instead listen for mouse and touch releases, set one or both of the props on your component called `outsideMouseEventType` and `outsideTouchEventType`.
+
+```
+  ...
+  getDefaultProps: function () {
+    return {
+      ...,
+      outsideMouseEventType: 'mouseup'
+    };
+  },
+  ...
+```
+
 ## Regulate whether or not to listen for outside clicks
 
 When using this mixin, a component has two functions that can be used to explicitly listen for, or do nothing with, outside clicks
@@ -64,7 +79,7 @@ When using this mixin, a component has two functions that can be used to explici
 - `enableOnClickOutside()` - Enables outside click listening by setting up the event listening bindings.
 - `disableOnClickOutside()` - Disables outside click listening by explicitly removing the event listening bindings.
  
-In addition, you can create a component that uses this mixin such that it has the code set up and ready to go, but not listening for outside click events until you explicitly issue its `enableOnClickOutside()`, by passing in a properly called `disableOnClickOutside`:
+In addition, you can create a component that uses this mixin such that it has the code set up and ready to go, but not listening for outside click events until you explicitly issue its `enableOnClickOutside()`, by passing in a property called `disableOnClickOutside`:
 
 ```
 var Component = React.createClass({

--- a/index.js
+++ b/index.js
@@ -103,10 +103,14 @@
      * Can be called to explicitly enable event listening
      * for clicks and touches outside of this element.
      */
-    enableOnClickOutside: function() {
+    enableOnClickOutside: function(opts) {
+      var opts = opts || {};
+      this.__outsideMouseEventType = opts.mouseup ? 'mouseup' : 'mousedown';
+      this.__outsideTouchEventType = opts.mouseup ? 'touchstart' : 'touchend';
+
       var fn = this.__outsideClickHandler;
-      document.addEventListener(this.props.outsideMouseEventType || "mousedown", fn);
-      document.addEventListener(this.props.outsideTouchEventType || "touchstart", fn);
+      document.addEventListener(this.__outsideMouseEventType, fn);
+      document.addEventListener(this.__outsideTouchEventType, fn);
     },
 
     /**
@@ -115,8 +119,8 @@
      */
     disableOnClickOutside: function() {
       var fn = this.__outsideClickHandler;
-      document.removeEventListener(this.props.outsideMouseEventType || "mousedown", fn);
-      document.removeEventListener(this.props.outsideTouchEventType || "touchstart", fn);
+      document.removeEventListener(this.__outsideMouseEventType, fn);
+      document.removeEventListener(this.__outsideTouchEventType, fn);
     }
   };
 

--- a/index.js
+++ b/index.js
@@ -105,8 +105,8 @@
      */
     enableOnClickOutside: function() {
       var fn = this.__outsideClickHandler;
-      document.addEventListener("mousedown", fn);
-      document.addEventListener("touchstart", fn);
+      document.addEventListener(this.props.outsideMouseEventType || "mousedown", fn);
+      document.addEventListener(this.props.outsideTouchEventType || "touchstart", fn);
     },
 
     /**
@@ -115,8 +115,8 @@
      */
     disableOnClickOutside: function() {
       var fn = this.__outsideClickHandler;
-      document.removeEventListener("mousedown", fn);
-      document.removeEventListener("touchstart", fn);
+      document.removeEventListener(this.props.outsideMouseEventType || "mousedown", fn);
+      document.removeEventListener(this.props.outsideTouchEventType || "touchstart", fn);
     }
   };
 


### PR DESCRIPTION
I have a use case where I'd like to listen to outside mouse releases, not presses. There's many ways to do it, but the least intrusive is to just allow a prop that sets the evt type to listen on. Thoughts?
Tested and works fine on desktop and mobile.