### PR TITLE
remove root from global document

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@
      */
     enableOnClickOutside: function() {
       var fn = this.__outsideClickHandler;
-      if (root.document != null) {
+      if (document != null) {
         document.addEventListener("mousedown", fn);
         document.addEventListener("touchstart", fn);
       }
@@ -119,7 +119,7 @@
      */
     disableOnClickOutside: function() {
       var fn = this.__outsideClickHandler;
-      if (root.document != null) {
+      if (document != null) {
         document.removeEventListener("mousedown", fn);
         document.removeEventListener("touchstart", fn);
       }


### PR DESCRIPTION
Hi there. I couldn't get the decorator work in React 0.14.2 and tracked it down to root.document always evaluating to null. Not sure why "root" was included there as document is a global variable. This fixes it.