### PR TITLE
readme update for accurate browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a React mixin that you can add to your React components if you want to have them listen for clicks that occur somewhere in the document, outside of the element itself (for instance, if you need to hide a menu when people click anywhere else on your page).
 
-Note that this mixin relies on the `.classList` property, which is supported by all modern browsers, but not by no longer supported browsers like IE8 or even older. For setups that need to support deprecated browsers, using something like the [MDN classlist-polyfill](https://www.npmjs.com/package/classlist-polyfill) will be necessary.
+Note that this mixin relies on the `.classList` property, which is supported by all modern browsers, but not by no longer supported browsers like IE9 or even older. For setups that need to support deprecated browsers, using something like the [MDN classlist-polyfill](https://www.npmjs.com/package/classlist-polyfill) will be necessary.
 
 ## installation
 
@@ -63,7 +63,7 @@ When using this mixin, a component has two functions that can be used to explici
 
 - `enableOnClickOutside()` - Enables outside click listening by setting up the event listening bindings.
 - `disableOnClickOutside()` - Disables outside click listening by explicitly removing the event listening bindings.
- 
+
 In addition, you can create a component that uses this mixin such that it has the code set up and ready to go, but not listening for outside click events until you explicitly issue its `enableOnClickOutside()`, by passing in a properly called `disableOnClickOutside`:
 
 ```javascript
@@ -87,12 +87,12 @@ If you want the mixin to ignore certain elements, then add the class `ignore-rea
 
 ## ES6/2015 class support via HOC / ES7 decorators
 
-Since mixins can't be used with ES6/2015 class React components a 
-[Higher-Order Component (HOC)](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) 
-and [ES7 decorator](https://github.com/wycats/javascript-decorators) are bundled with the mixin: 
+Since mixins can't be used with ES6/2015 class React components a
+[Higher-Order Component (HOC)](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750)
+and [ES7 decorator](https://github.com/wycats/javascript-decorators) are bundled with the mixin:
 
 ```javascript
-import listensToClickOutside from 'react-onclickoutside/decorator'; 
+import listensToClickOutside from 'react-onclickoutside/decorator';
 
 class Component extends React.Component {
   handleClickOutside = (event) => {
@@ -104,7 +104,7 @@ export default listensToClickOutside(Component);
 
 // OR
 
-import listensToClickOutside from 'react-onclickoutside/decorator'; 
+import listensToClickOutside from 'react-onclickoutside/decorator';
 
 @listensToClickOutside()
 class Component extends React.Component {
@@ -120,7 +120,7 @@ One difference when using the HOC/decorator compared to the mixin is that the `e
 and `disableOnClickOutside()` methods are not available as class methods, but rather on the `props`;
 so instead of `this.enableOnClickOutside()` you would call `this.props.enableOnClickOutside()`.
 
-In every other respect the the mixin and HOC/decorator provides the same functionality. 
+In every other respect the the mixin and HOC/decorator provides the same functionality.
 
 For bugs and enhancements hit up https://github.com/Pomax/react-onclickoutside/issues
 


### PR DESCRIPTION
The ReadMe had me believing that this library would support IE9. But IE9 [does not support classList](http://caniuse.com/#search=classList). I checked IE9 and I had been getting `Unable to get value of the property 'contains': object is null or undefined`. Thanks for recommending the polyfill I will check it out.