### PR TITLE
Allow specification of ignore class by prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ var Container = React.createClass({
 
 ## Marking elements as "skip over this one" during the event loop
 
-If you want the mixin to ignore certain elements, then add the class `ignore-react-onclickoutside` to that element and the callback won't be invoked when the click happens inside elements with that class.
+If you want the mixin to ignore certain elements, then add the class `ignore-react-onclickoutside` to that element and the callback won't be invoked when the click happens inside elements with that class. This class can be changed by setting the `outsideClickIgnoreClass` property on the component.
 
 ## ES6/2015 class support via HOC / ES7 decorators
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@
 
   var IGNORE_CLASS = 'ignore-react-onclickoutside';
 
-  var isSourceFound = function(source, localNode) {
+  var isSourceFound = function(source, localNode, ignoreClass) {
     if (source === localNode) {
       return true;
     }
@@ -48,9 +48,9 @@
     // See: http://www.w3.org/TR/SVG11/struct.html#InterfaceSVGUseElement
     // Discussion: https://github.com/Pomax/react-onclickoutside/pull/17
     if (source.correspondingElement) {
-      return source.correspondingElement.classList.contains(IGNORE_CLASS);
+      return source.correspondingElement.classList.contains(ignoreClass);
     }
-    return source.classList.contains(IGNORE_CLASS);
+    return source.classList.contains(ignoreClass);
   };
 
   return {
@@ -63,13 +63,14 @@
           evt.stopPropagation();
           var source = evt.target;
           var found = false;
+          var ignoreClass = this.props.outsideClickIgnoreClass || IGNORE_CLASS;
           // If source=local then this event came from "somewhere"
           // inside and should be ignored. We could handle this with
           // a layered approach, too, but that requires going back to
           // thinking in terms of Dom node nesting, running counter
           // to React's "you shouldn't care about the DOM" philosophy.
           while(source.parentNode) {
-            found = isSourceFound(source, localNode);
+            found = isSourceFound(source, localNode, ignoreClass);
             if(found) return;
             source = source.parentNode;
           }


### PR DESCRIPTION
Addresses #37

This allows consumers to get rid of the `'ignore-react-onclickoutside'` magic string in app code and use `IGNORE_CLASS` as the source of truth instead.