### PR TITLE
IE11 SVG's don't have classList or correspondingElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ var Container = React.createClass({
 ## Marking elements as "skip over this one" during the event loop
 
 If you want the mixin to ignore certain elements, then add the class `ignore-react-onclickoutside` to that element and the callback won't be invoked when the click happens inside elements with that class.
+Note: Using a class to skip over elements will not work in browsers that do not support the `classList` or `correspondingElement` properties on SVGs (e.g. IE11.)
 
 ## ES6/2015 class support via HOC / ES7 decorators
 

--- a/index.js
+++ b/index.js
@@ -49,8 +49,11 @@
     // Discussion: https://github.com/Pomax/react-onclickoutside/pull/17
     if (source.correspondingElement) {
       return source.correspondingElement.classList.contains(IGNORE_CLASS);
+    } else if (source.classList) {
+      return source.classList.contains(IGNORE_CLASS);
+    } else {
+      return false;
     }
-    return source.classList.contains(IGNORE_CLASS);
   };
 
   return {


### PR DESCRIPTION
SVG's in IE11 don't support classList or correspondingElement.
When clicking on an SVG it throws an error.
Test Case:
http://codepen.io/mohicanlove/pen/JXJzPE?editors=1111

This PR updates the `IGNORE_CLASS`  check so it returns false instead of raising an error when neither property is available.