### PR TITLE
Changed HOC/decorator to favor enable/disableClickOutside over this.props, rather than visa-versa.

### DIFF
--- a/decorator.js
+++ b/decorator.js
@@ -21,11 +21,11 @@ function addClickOutsideListener(Component) {
     },
 
     render: function render() {
-      return React.createElement(Component, objectAssign({
+      return React.createElement(Component, objectAssign({}, this.props, {
         enableOnClickOutside: this.enableOnClickOutside,
         disableOnClickOutside: this.disableOnClickOutside,
         ref: 'inner'
-      }, this.props));
+      }));
     }
   });
 }


### PR DESCRIPTION
Fix for #65
Prior to this change, passing `enableOnClickOutside` or `disableOnClickOutside` as props to the HOC(component) will override the functions of the same name passed by the HOC to the wrapped component, which is not consistent with how the mixin works.

With this change, the internal function properties will now supersede the properties from the parent, allowing the component to enable/disable listening. Technically, this is a breaking change, but the documentation would seem to suggest it should work like this (the same as the mixin), rather than how it does currently.