### PR TITLE
prevent undefined error if called server side

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@
      */
     enableOnClickOutside: function() {
       var fn = this.__outsideClickHandler;
-      if (document != null) {
+      if (typeof document !== "undefined") {
         document.addEventListener("mousedown", fn);
         document.addEventListener("touchstart", fn);
       }
@@ -122,7 +122,7 @@
      */
     disableOnClickOutside: function() {
       var fn = this.__outsideClickHandler;
-      if (document != null) {
+      if (typeof document !== "undefined") {
         document.removeEventListener("mousedown", fn);
         document.removeEventListener("touchstart", fn);
       }


### PR DESCRIPTION
does the same thing as before (not attaching handlers)
except it doesn't throw anymore if there is no document