### PR TITLE
Enable dynamic disableOnClickOutside

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,17 @@
         },
 
         /**
+        * Track for disableOnClickOutside props changes and enable/disable click outside
+        */
+        componentWillReceiveProps: function(nextProps) {
+          if (this.props.disableOnClickOutside && !nextProps.disableOnClickOutside) {
+            this.enableOnClickOutside();
+          } else if (this.props.disableOnClickOutside && !nextProps.disableOnClickOutside) {
+            this.disableOnClickOutside();
+          }
+        },
+
+        /**
          * Remove the document's event listeners
          */
         componentWillUnmount: function() {


### PR DESCRIPTION
Thanks for awesome project! Unfortunately I have found it quite hard to use, for a simple case: list with elements you can select/deselect.

As I'm using redux all the data are passed down as a prop and the component state should be change according to those props. 

With the current plugin state triggering OnClickOutside for multiple list elements was hard and required a lot of not DRY code. With this simple fix, the only thing user have to do is change `disableOnClickOutside` from `false` to `true`.