### PR TITLE
Fix - properly disable outside click listening on props change

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@
         componentWillReceiveProps: function(nextProps) {
           if (this.props.disableOnClickOutside && !nextProps.disableOnClickOutside) {
             this.enableOnClickOutside();
-          } else if (this.props.disableOnClickOutside && !nextProps.disableOnClickOutside) {
+          } else if (!this.props.disableOnClickOutside && nextProps.disableOnClickOutside) {
             this.disableOnClickOutside();
           }
         },


### PR DESCRIPTION
Fixes #92 - Disable outside click listening when the HOC's disableOnClickOutside prop flips from false to true.