### PR TITLE
Update index.js to use click event and not mousedown

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
             var events = this.props.eventTypes || DEFAULT_EVENTS;
+            if (!events.forEach) { events = [events] };
             events.forEach(function (eventName) {
               document.addEventListener(eventName, fn);
             });
@@ -170,6 +171,7 @@
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
             var events = this.props.eventTypes || DEFAULT_EVENTS;
+            if (!events.forEach) { events = [events] };
             events.forEach(function (eventName) {
               document.removeEventListener(eventName, fn);
             });

--- a/index.js
+++ b/index.js
@@ -154,8 +154,10 @@
         enableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
-            document.addEventListener("click", fn);
-            document.addEventListener("touchstart", fn);
+            var events = this.props.eventTypes || ["mousedown", "touchstart"];
+            events.forEach(function (eventName) {
+              document.addEventListener(eventName, fn);
+            });
           }
         },
 
@@ -166,8 +168,10 @@
         disableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
-            document.removeEventListener("click", fn);
-            document.removeEventListener("touchstart", fn);
+            var events = this.props.eventTypes || ["mousedown", "touchstart"];
+            events.forEach(function (eventName) {
+              document.removeEventListener(eventName, fn);
+            });
           }
         },
 

--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@
         enableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
-            document.addEventListener("mousedown", fn);
+            document.addEventListener("click", fn);
             document.addEventListener("touchstart", fn);
           }
         },
@@ -166,7 +166,7 @@
         disableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
-            document.removeEventListener("mousedown", fn);
+            document.removeEventListener("click", fn);
             document.removeEventListener("touchstart", fn);
           }
         },

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@
   var registeredComponents = [];
   var handlers = [];
   var IGNORE_CLASS = 'ignore-react-onclickoutside';
+  var DEFAULT_EVENTS = ['mousedown', 'touchstart'];
 
   /**
    * Check whether some DOM node is our Component's node.
@@ -154,7 +155,7 @@
         enableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
-            var events = this.props.eventTypes || ["mousedown", "touchstart"];
+            var events = this.props.eventTypes || DEFAULT_EVENTS;
             events.forEach(function (eventName) {
               document.addEventListener(eventName, fn);
             });
@@ -168,7 +169,7 @@
         disableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
-            var events = this.props.eventTypes || ["mousedown", "touchstart"];
+            var events = this.props.eventTypes || DEFAULT_EVENTS;
             events.forEach(function (eventName) {
               document.removeEventListener(eventName, fn);
             });


### PR DESCRIPTION
if the state of a component changes based on the outside click we want the target area to receive the completed event before modifying state.

take an accordion menu component for example - if an area above the next target collapses, we want to wait until the event is complete so that the next item can expand as a result of state change.