### PR TITLE
Avoid `console.warn` via delegation, fixes #89

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@
     }
   };
 
+
   /**
    * This function generates the HOC function that you'll use
    * in order to impart onOutsideClick listening to an

--- a/index.js
+++ b/index.js
@@ -60,16 +60,6 @@
     }
   };
 
-  /*
-   * A workaround for issue #89, where React will emit a console.warn when it
-   * detects methods bound using `.bind`
-   */
-  var delegateHandler = function(instance) {
-    return function() {
-      instance.handleClickOutside.apply(instance, arguments);
-    }
-  };
-
   /**
    * This function generates the HOC function that you'll use
    * in order to impart onOutsideClick listening to an
@@ -115,7 +105,7 @@
 
           var fn = this.__outsideClickHandler = generateOutsideCheck(
             ReactDOM.findDOMNode(instance),
-            delegateHandler(instance),
+            instance.handleClickOutside.bind(instance, undefined),
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
             this.props.preventDefault || false,
             this.props.stopPropagation || false

--- a/index.js
+++ b/index.js
@@ -60,6 +60,15 @@
     }
   };
 
+  /*
+   * A workaround for issue #89, where React will emit a console.warn when it
+   * detects methods bound using `.bind`
+   */
+  var delegateHandler = function(instance) {
+    return function() {
+      instance.handleClickOutside.apply(instance, arguments);
+    }
+  };
 
   /**
    * This function generates the HOC function that you'll use
@@ -104,16 +113,9 @@
             throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
           }
 
-          // react@15.x will emit warnings when methods are bound using the
-          // .bind() syntax; this provides a way to delegate to
-          // `handleClickOutside` without React emitting a `console.warn`.
-          var delegateHandler = function() {
-            instance.handleClickOutside.apply(instance, arguments);
-          }
-
           var fn = this.__outsideClickHandler = generateOutsideCheck(
             ReactDOM.findDOMNode(instance),
-            delegateHandler,
+            delegateHandler(instance),
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
             this.props.preventDefault || false,
             this.props.stopPropagation || false

--- a/index.js
+++ b/index.js
@@ -104,9 +104,16 @@
             throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
           }
 
+          // react@15.x will emit warnings when methods are bound using the
+          // .bind() syntax; this provides a way to delegate to
+          // `handleClickOutside` without React emitting a `console.warn`.
+          var delegateHandler = function() {
+            instance.handleClickOutside.apply(instance, arguments);
+          }
+
           var fn = this.__outsideClickHandler = generateOutsideCheck(
             ReactDOM.findDOMNode(instance),
-            instance.handleClickOutside.bind(instance),
+            delegateHandler,
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
             this.props.preventDefault || false,
             this.props.stopPropagation || false


### PR DESCRIPTION
Hello!

We were also experiencing the issues reported in #89. It looks like we can avoid that warning by providing the context to `handleClickOutside` in a way that `React` doesn't take issue with.

Tests output before and after:

<img width="751" alt="screen shot 2016-06-15 at 17 14 31" src="https://cloud.githubusercontent.com/assets/926283/16087807/39ff6d36-331c-11e6-8913-b328954d6e7f.png">

Let me know if there are any changes required!
