### PR TITLE
Add enable/disableOnClickOutside prop. Fixes #106

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@
 
           var fn = this.__outsideClickHandler = generateOutsideCheck(
             ReactDOM.findDOMNode(instance),
-            instance.handleClickOutside.bind(instance, undefined),
+            instance.handleClickOutside.bind(instance),
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
             this.props.preventDefault || false,
             this.props.stopPropagation || false

--- a/index.js
+++ b/index.js
@@ -183,10 +183,13 @@
          */
         render: function() {
           var passedProps = this.props;
-          var props = { ref: 'instance' };
+          var props = {};
           Object.keys(this.props).forEach(function(key) {
             props[key] = passedProps[key];
           });
+          props.ref = 'instance';
+          props.disableOnClickOutside = this.disableOnClickOutside;
+          props.enableOnClickOutside = this.enableOnClickOutside;
           return React.createElement(Component,  props);
         }
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-onclickoutside",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "An onClickOutside mixin for React components",
   "main": "index.js",
   "homepage": "https://github.com/Pomax/react-onclickoutside",

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,11 @@ describe('onclickoutside hoc', function() {
       };
     },
 
-    handleClickOutside: function() {
+    handleClickOutside: function(event) {
+      if (event === undefined) {
+          throw new Error("event cannot be undefined");
+      }
+
       this.setState({
         clickOutsideHandled: true
       });

--- a/test/test.js
+++ b/test/test.js
@@ -5,11 +5,29 @@ var wrapComponent = require('../index');
 
 describe('onclickoutside hoc', function() {
 
+  var externalToggleEnableClickOutside;
+
   var Component = React.createClass({
     getInitialState: function() {
       return {
-        clickOutsideHandled: false
+        clickOutsideHandled: false,
+        timesHandlerCalled: 0
       };
+    },
+
+    toggleEnableClickOutside: function(on) {
+      if(on) {
+        this.props.enableOnClickOutside();
+      }
+      else {
+        this.props.disableOnClickOutside();
+      }
+    },
+
+    componentDidMount: function() {
+      externalToggleEnableClickOutside = function(on) {
+        this.toggleEnableClickOutside(on);
+      }.bind(this);
     },
 
     handleClickOutside: function(event) {
@@ -18,7 +36,8 @@ describe('onclickoutside hoc', function() {
       }
 
       this.setState({
-        clickOutsideHandled: true
+        clickOutsideHandled: true,
+        timesHandlerCalled: this.state.timesHandlerCalled + 1
       });
     },
 
@@ -55,5 +74,27 @@ describe('onclickoutside hoc', function() {
     } catch (e) {
       assert(e, "component was not wrapped");
     }
+  });
+
+  it('should not call handleClickOutside if this.props.disableOnClickOutside() is called, until this.props.enableOnClickOutside() is called.', function() {
+    var element = React.createElement(WrappedComponent);
+    var component = TestUtils.renderIntoDocument(element);
+    document.dispatchEvent(new Event('mousedown'));
+    var instance = component.getInstance();
+    assert(instance.state.timesHandlerCalled === 1, "handleClickOutside called");
+
+    try {
+      externalToggleEnableClickOutside(false);
+    }
+    catch(error) {
+      assert(false, 'this.props.disableOnClickOutside() should not be undefined.');
+    }
+
+    document.dispatchEvent(new Event('mousedown'));
+    assert(instance.state.timesHandlerCalled === 1, "handleClickOutside not called after disableOnClickOutside()");
+
+    externalToggleEnableClickOutside(true);
+    document.dispatchEvent(new Event('mousedown'));
+    assert(instance.state.timesHandlerCalled === 2, "handleClickOutside called after enableOnClickOutside()");
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -5,8 +5,6 @@ var wrapComponent = require('../index');
 
 describe('onclickoutside hoc', function() {
 
-  var externalToggleEnableClickOutside;
-
   var Component = React.createClass({
     getInitialState: function() {
       return {
@@ -22,12 +20,6 @@ describe('onclickoutside hoc', function() {
       else {
         this.props.disableOnClickOutside();
       }
-    },
-
-    componentDidMount: function() {
-      externalToggleEnableClickOutside = function(on) {
-        this.toggleEnableClickOutside(on);
-      }.bind(this);
     },
 
     handleClickOutside: function(event) {
@@ -84,7 +76,7 @@ describe('onclickoutside hoc', function() {
     assert(instance.state.timesHandlerCalled === 1, "handleClickOutside called");
 
     try {
-      externalToggleEnableClickOutside(false);
+      instance.toggleEnableClickOutside(false);
     }
     catch(error) {
       assert(false, 'this.props.disableOnClickOutside() should not be undefined.');
@@ -93,7 +85,7 @@ describe('onclickoutside hoc', function() {
     document.dispatchEvent(new Event('mousedown'));
     assert(instance.state.timesHandlerCalled === 1, "handleClickOutside not called after disableOnClickOutside()");
 
-    externalToggleEnableClickOutside(true);
+    instance.toggleEnableClickOutside(true);
     document.dispatchEvent(new Event('mousedown'));
     assert(instance.state.timesHandlerCalled === 2, "handleClickOutside called after enableOnClickOutside()");
   });


### PR DESCRIPTION
Fixes https://github.com/Pomax/react-onclickoutside/issues/106

This change adds enableOnClickOutside and disableOnClickOutside props back to the wrapped component, equivalent to the 4.x decorator/HoC version of the library.

This isn't the prettiest solution, in my own code I would use Object.assign. But, this code will work where Object.assign doesn't exist.

In the future, should this library be converted to use an ES2015 class component rather than createClass, this bit of code will need to be changed to bind the functions to `this` before adding them to the wrapped component's props.