### PR TITLE
Add support for config, allow users to specify onClickOutside handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,27 @@ var MyComponent = onClickOutside(React.createClass({
 }));
 
 ```
+Note that if you try to wrap a React component class without `handleClickOutside(evt)` handler like this, the HOC will throw an error.
+If you want to execute method different than `handleClickOutside(evt)`, you can specify it as a second parameter to `onClickOutside` like this:
 
-Note that if you try to wrap a React component class without `handleClickOutside(evt)` handler, the HOC will throw an error. If you want onClickOutside functionality, you *must* have this function defined.
+```javascript
+// load the HOC:
+var onClickOutside = require('react-onclickoutside');
+
+// create a new component, wrapped by this onclickoutside HOC:
+var MyComponent = onClickOutside(React.createClass({
+  ...,
+  myClickOutsideHandler: function(evt) {
+    // ...handling code goes here...
+  },
+  ...
+}), function (instance) {
+    instance.myClickOutsideHandler
+});
+
+```
+
+Note that if you try to wrap a React component class while specifying a custom handler and the component does not implement it, the HOC will throw an error.
 
 ## Regulate which events to listen for
 

--- a/README.md
+++ b/README.md
@@ -19,44 +19,32 @@ $> npm install react-onclickoutside --save
 var onClickOutside = require('react-onclickoutside');
 
 // create a new component, wrapped by this onclickoutside HOC:
-var MyComponent = onClickOutside(
-    // ...config can go here...
-)(React.createClass({
+var MyComponent = onClickOutside(React.createClass({
   ...,
-  handleClickOutside: function (evt) {
+  handleClickOutside: function(evt) {
     // ...handling code goes here...
   },
   ...
 }));
 
-// to maintain compatibility with previous versions, the wrapper can be also called like this:
-var MyLegacyComponent = onClickOutside(React.createClass({
-  ...,
-  handleClickOutside: function (evt) {
-    // ...handling code goes here...
-  },
-  ...
-}));
 ```
 Note that if you try to wrap a React component class without `handleClickOutside(evt)` handler like this, the HOC will throw an error.
-If you want to execute method different than `handleClickOutside(evt)`, you can specify it using the config parameter of `onClickOutside` like this:
+If you want to execute method different than `handleClickOutside(evt)`, you can specify it as a second parameter to `onClickOutside` like this:
 
 ```javascript
 // load the HOC:
 var onClickOutside = require('react-onclickoutside');
 
 // create a new component, wrapped by this onclickoutside HOC:
-var MyComponent = onClickOutside({
-    onClickOutside: function (instance) {
-        return instance.myClickOutsideHandler;
-    }
-})(React.createClass({
+var MyComponent = onClickOutside(React.createClass({
   ...,
-  myClickOutsideHandler: function (evt) {
+  myClickOutsideHandler: function(evt) {
     // ...handling code goes here...
   },
   ...
-}));
+}), function (instance) {
+    instance.myClickOutsideHandler
+});
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ var MyComponent = onClickOutside(React.createClass({
 }));
 
 ```
-Note that if you try to wrap a React component class without `handleClickOutside(evt)` handler like this, the HOC will throw an error.
-If you want to execute method different than `handleClickOutside(evt)`, you can specify it as a second parameter to `onClickOutside` like this:
+Note that if you try to wrap a React component class without a `handleClickOutside(evt)` handler like this, the HOC will throw an error.
+In order to use a custom event handler, you can specify the function to be used by the HOC as second parameter
+(this can be useful in environments like TypeScript, where the fact, that the wrapped component does not implement the handler becomes apparent at compile-time):
 
 ```javascript
 // load the HOC:
@@ -42,13 +43,15 @@ var MyComponent = onClickOutside(React.createClass({
     // ...handling code goes here...
   },
   ...
-}), function (instance) {
-    instance.myClickOutsideHandler
+}), {
+  handleClickOutside: function(instance) {
+    return instance.myClickOutsideHandler;
+  }
 });
 
 ```
 
-Note that if you try to wrap a React component class while specifying a custom handler and the component does not implement it, the HOC will throw an error.
+Note that if you try to wrap a React component class while specifying a custom handler and the component does not implement it, the HOC will throw an error at run-time.
 
 ## Regulate which events to listen for
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,20 @@ var MyComponent = onClickOutside(
     // ...config can go here...
 )(React.createClass({
   ...,
-  handleClickOutside: function(evt) {
+  handleClickOutside: function (evt) {
     // ...handling code goes here...
   },
   ...
 }));
 
+// to maintain compatibility with previous versions, the wrapper can be also called like this:
+var MyLegacyComponent = onClickOutside(React.createClass({
+  ...,
+  handleClickOutside: function (evt) {
+    // ...handling code goes here...
+  },
+  ...
+}));
 ```
 Note that if you try to wrap a React component class without `handleClickOutside(evt)` handler like this, the HOC will throw an error.
 If you want to execute method different than `handleClickOutside(evt)`, you can specify it using the config parameter of `onClickOutside` like this:
@@ -44,7 +52,7 @@ var MyComponent = onClickOutside({
     }
 })(React.createClass({
   ...,
-  myClickOutsideHandler: function(evt) {
+  myClickOutsideHandler: function (evt) {
     // ...handling code goes here...
   },
   ...

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ $> npm install react-onclickoutside --save
 var onClickOutside = require('react-onclickoutside');
 
 // create a new component, wrapped by this onclickoutside HOC:
-var MyComponent = onClickOutside(React.createClass({
+var MyComponent = onClickOutside(
+    // ...config can go here...
+)(React.createClass({
   ...,
   handleClickOutside: function(evt) {
     // ...handling code goes here...
@@ -29,22 +31,24 @@ var MyComponent = onClickOutside(React.createClass({
 
 ```
 Note that if you try to wrap a React component class without `handleClickOutside(evt)` handler like this, the HOC will throw an error.
-If you want to execute method different than `handleClickOutside(evt)`, you can specify it as a second parameter to `onClickOutside` like this:
+If you want to execute method different than `handleClickOutside(evt)`, you can specify it using the config parameter of `onClickOutside` like this:
 
 ```javascript
 // load the HOC:
 var onClickOutside = require('react-onclickoutside');
 
 // create a new component, wrapped by this onclickoutside HOC:
-var MyComponent = onClickOutside(React.createClass({
+var MyComponent = onClickOutside({
+    onClickOutside: function (instance) {
+        return instance.myClickOutsideHandler;
+    }
+})(React.createClass({
   ...,
   myClickOutsideHandler: function(evt) {
     // ...handling code goes here...
   },
   ...
-}), function (instance) {
-    instance.myClickOutsideHandler
-});
+}));
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@
   function setupHOC(root, React, ReactDOM) {
 
     // The actual Component-wrapping HOC:
-    return function(Component) {
+    return function(Component, clickOutsideHandlerAccessor) {
       var wrapComponentWithOnClickOutsideHandling = React.createClass({
         statics: {
           /**
@@ -99,14 +99,23 @@
          */
         componentDidMount: function() {
           var instance = this.getInstance();
+          var clickOutsideHandler;
 
-          if(typeof instance.handleClickOutside !== "function") {
-            throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
+          if(typeof clickOutsideHandlerAccessor === "function") {
+            clickOutsideHandler = clickOutsideHandlerAccessor(instance);
+            if(typeof clickOutsideHandler !== "function") {
+              throw new Error("Component lacks a function for processing outside click events specified by the clickOutsideHandlerAccessor parameter.");
+            }
+          } else {
+              if(typeof instance.handleClickOutside !== "function") {
+                throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
+            }
+            clickOutsideHandler = instance.handleClickOutside;
           }
 
           var fn = this.__outsideClickHandler = generateOutsideCheck(
             ReactDOM.findDOMNode(instance),
-            instance.handleClickOutside.bind(instance),
+            clickOutsideHandler.bind(instance),
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
             this.props.preventDefault || false,
             this.props.stopPropagation || false

--- a/index.js
+++ b/index.js
@@ -104,21 +104,21 @@
           if(typeof clickOutsideAccessor === "function") {
             clickOutsideHandler = clickOutsideAccessor(instance);
             if(typeof clickOutsideHandler !== "function") {
-              throw new Error("Component lacks a function for processing outside click events specified by the onClickOutside parameter.");
+              throw new Error("Component lacks a function for processing outside click events specified by the onClickOutside config parameter.");
             }
           } else {
-              if(typeof instance.handleClickOutside !== "function") {
-                throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
-              }
-              clickOutsideHandler = instance.handleClickOutside;
+            if(typeof instance.handleClickOutside !== "function") {
+              throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
+            }
+            clickOutsideHandler = instance.handleClickOutside;
           }
 
           var fn = this.__outsideClickHandler = generateOutsideCheck(
-              ReactDOM.findDOMNode(instance),
-              clickOutsideHandler.bind(instance),
-              this.props.outsideClickIgnoreClass || IGNORE_CLASS,
-              this.props.preventDefault || false,
-              this.props.stopPropagation || false
+            ReactDOM.findDOMNode(instance),
+            clickOutsideHandler.bind(instance),
+            this.props.outsideClickIgnoreClass || IGNORE_CLASS,
+            this.props.preventDefault || false,
+            this.props.stopPropagation || false
           );
 
           var pos = registeredComponents.length;
@@ -128,7 +128,7 @@
           // If there is a truthy disableOnClickOutside property for this
           // component, don't immediately start listening for outside events.
           if (!this.props.disableOnClickOutside) {
-              this.enableOnClickOutside();
+            this.enableOnClickOutside();
           }
         },
 
@@ -137,9 +137,9 @@
         */
         componentWillReceiveProps: function(nextProps) {
           if (this.props.disableOnClickOutside && !nextProps.disableOnClickOutside) {
-              this.enableOnClickOutside();
+            this.enableOnClickOutside();
           } else if (!this.props.disableOnClickOutside && nextProps.disableOnClickOutside) {
-              this.disableOnClickOutside();
+            this.disableOnClickOutside();
           }
         },
 
@@ -151,9 +151,9 @@
           this.__outsideClickHandler = false;
           var pos = registeredComponents.indexOf(this);
           if( pos>-1) {
-              // clean up so we don't leak memory
-              if (handlers[pos]) { handlers.splice(pos, 1); }
-              registeredComponents.splice(pos, 1);
+            // clean up so we don't leak memory
+            if (handlers[pos]) { handlers.splice(pos, 1); }
+            registeredComponents.splice(pos, 1);
           }
         },
 
@@ -164,11 +164,11 @@
         enableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
-              var events = this.props.eventTypes || DEFAULT_EVENTS;
-              if (!events.forEach) { events = [events] };
-              events.forEach(function (eventName) {
+            var events = this.props.eventTypes || DEFAULT_EVENTS;
+            if (!events.forEach) { events = [events] };
+            events.forEach(function (eventName) {
               document.addEventListener(eventName, fn);
-              });
+            });
           }
         },
 
@@ -179,11 +179,11 @@
         disableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
           if (typeof document !== "undefined") {
-              var events = this.props.eventTypes || DEFAULT_EVENTS;
-              if (!events.forEach) { events = [events] };
-              events.forEach(function (eventName) {
+            var events = this.props.eventTypes || DEFAULT_EVENTS;
+            if (!events.forEach) { events = [events] };
+            events.forEach(function (eventName) {
               document.removeEventListener(eventName, fn);
-              });
+            });
           }
         },
 
@@ -194,7 +194,7 @@
           var passedProps = this.props;
           var props = { ref: 'instance' };
           Object.keys(this.props).forEach(function(key) {
-              props[key] = passedProps[key];
+            props[key] = passedProps[key];
           });
           return React.createElement(Component,  props);
         }
@@ -202,8 +202,8 @@
 
       // Add display name for React devtools
       (function bindWrappedComponentName(c, wrapper) {
-          var componentName = c.displayName || c.name || 'Component'
-          wrapper.displayName = 'OnClickOutside(' + componentName + ')';
+        var componentName = c.displayName || c.name || 'Component'
+        wrapper.displayName = 'OnClickOutside(' + componentName + ')';
       }(Component, wrapComponentWithOnClickOutsideHandling));
 
       return wrapComponentWithOnClickOutsideHandling;

--- a/index.js
+++ b/index.js
@@ -68,7 +68,8 @@
    */
   function setupHOC(root, React, ReactDOM) {
 
-    var hocBody = function(Component, config) {
+    // The actual Component-wrapping HOC:
+    return function(Component, clickOutsideHandlerAccessor) {
       var wrapComponentWithOnClickOutsideHandling = React.createClass({
         statics: {
           /**
@@ -98,17 +99,16 @@
          */
         componentDidMount: function() {
           var instance = this.getInstance();
-          var clickOutsideAccessor = config && config.onClickOutside;
           var clickOutsideHandler;
 
-          if(typeof clickOutsideAccessor === "function") {
-            clickOutsideHandler = clickOutsideAccessor(instance);
+          if(typeof clickOutsideHandlerAccessor === "function") {
+            clickOutsideHandler = clickOutsideHandlerAccessor(instance);
             if(typeof clickOutsideHandler !== "function") {
-              throw new Error("Component lacks a function for processing outside click events specified by the onClickOutside config parameter.");
+              throw new Error("Component lacks a function for processing outside click events specified by the clickOutsideHandlerAccessor parameter.");
             }
           } else {
-            if(typeof instance.handleClickOutside !== "function") {
-              throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
+              if(typeof instance.handleClickOutside !== "function") {
+                throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
             }
             clickOutsideHandler = instance.handleClickOutside;
           }
@@ -207,18 +207,6 @@
       }(Component, wrapComponentWithOnClickOutsideHandling));
 
       return wrapComponentWithOnClickOutsideHandling;
-    };
-
-    // The actual Component-wrapping HOC:
-    return function(configOrComponent) {
-      // Detect the legacy call
-      if (typeof configOrComponent === 'function'){
-        return hocBody(configOrComponent);
-      }
-
-      return function(Component) {
-        return hocBody(Component, configOrComponent);
-      };
     };
   }
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@
   function setupHOC(root, React, ReactDOM) {
 
     // The actual Component-wrapping HOC:
-    return function(Component, clickOutsideHandlerAccessor) {
+    return function(Component, config) {
       var wrapComponentWithOnClickOutsideHandling = React.createClass({
         statics: {
           /**
@@ -101,10 +101,10 @@
           var instance = this.getInstance();
           var clickOutsideHandler;
 
-          if(typeof clickOutsideHandlerAccessor === "function") {
-            clickOutsideHandler = clickOutsideHandlerAccessor(instance);
+          if(config && typeof config.handleClickOutside === "function") {
+            clickOutsideHandler = config.handleClickOutside(instance);
             if(typeof clickOutsideHandler !== "function") {
-              throw new Error("Component lacks a function for processing outside click events specified by the clickOutsideHandlerAccessor parameter.");
+              throw new Error("Component lacks a function for processing outside click events specified by the handleClickOutside config option.");
             }
           } else {
               if(typeof instance.handleClickOutside !== "function") {
@@ -116,7 +116,7 @@
           var fn = this.__outsideClickHandler = generateOutsideCheck(
             ReactDOM.findDOMNode(instance),
             instance,
-            clickOutsideHandler.bind(instance),
+            clickOutsideHandler,
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
             this.props.preventDefault || false,
             this.props.stopPropagation || false

--- a/index.js
+++ b/index.js
@@ -68,138 +68,136 @@
    */
   function setupHOC(root, React, ReactDOM) {
 
-    // The actual Component-wrapping HOC:
-    return function(config) {
-      return function(Component) {
+    var hocBody = function(Component, config) {
       var wrapComponentWithOnClickOutsideHandling = React.createClass({
-          statics: {
-            /**
-             * Access the wrapped Component's class.
-             */
-            getClass: function() {
-              if (Component.getClass) {
-                return Component.getClass();
-              }
-              return Component;
-            }
-          },
-
+        statics: {
           /**
-           * Access the wrapped Component's instance.
+           * Access the wrapped Component's class.
            */
-          getInstance: function() {
-            return this.refs.instance;
-          },
-
-          // this is given meaning in componentDidMount
-          __outsideClickHandler: function(evt) {},
-
-          /**
-           * Add click listeners to the current document,
-           * linked to this component's state.
-           */
-          componentDidMount: function() {
-            var instance = this.getInstance();
-            var clickOutsideAccessor = config && config.onClickOutside;
-            var clickOutsideHandler;
-
-            if(typeof clickOutsideAccessor === "function") {
-              clickOutsideHandler = clickOutsideAccessor(instance);
-              if(typeof clickOutsideHandler !== "function") {
-                throw new Error("Component lacks a function for processing outside click events specified by the onClickOutside parameter.");
-              }
-            } else {
-                if(typeof instance.handleClickOutside !== "function") {
-                  throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
-                }
-                clickOutsideHandler = instance.handleClickOutside;
+          getClass: function() {
+            if (Component.getClass) {
+              return Component.getClass();
             }
-
-            var fn = this.__outsideClickHandler = generateOutsideCheck(
-                ReactDOM.findDOMNode(instance),
-                clickOutsideHandler.bind(instance),
-                this.props.outsideClickIgnoreClass || IGNORE_CLASS,
-                this.props.preventDefault || false,
-                this.props.stopPropagation || false
-            );
-
-            var pos = registeredComponents.length;
-            registeredComponents.push(this);
-            handlers[pos] = fn;
-
-            // If there is a truthy disableOnClickOutside property for this
-            // component, don't immediately start listening for outside events.
-            if (!this.props.disableOnClickOutside) {
-                this.enableOnClickOutside();
-            }
-          },
-
-          /**
-          * Track for disableOnClickOutside props changes and enable/disable click outside
-          */
-          componentWillReceiveProps: function(nextProps) {
-            if (this.props.disableOnClickOutside && !nextProps.disableOnClickOutside) {
-                this.enableOnClickOutside();
-            } else if (!this.props.disableOnClickOutside && nextProps.disableOnClickOutside) {
-                this.disableOnClickOutside();
-            }
-          },
-
-          /**
-           * Remove the document's event listeners
-           */
-          componentWillUnmount: function() {
-            this.disableOnClickOutside();
-            this.__outsideClickHandler = false;
-            var pos = registeredComponents.indexOf(this);
-            if( pos>-1) {
-                // clean up so we don't leak memory
-                if (handlers[pos]) { handlers.splice(pos, 1); }
-                registeredComponents.splice(pos, 1);
-            }
-          },
-
-          /**
-           * Can be called to explicitly enable event listening
-           * for clicks and touches outside of this element.
-           */
-          enableOnClickOutside: function() {
-            var fn = this.__outsideClickHandler;
-            if (typeof document !== "undefined") {
-                var events = this.props.eventTypes || DEFAULT_EVENTS;
-                if (!events.forEach) { events = [events] };
-                events.forEach(function (eventName) {
-                document.addEventListener(eventName, fn);
-                });
-            }
-          },
-
-          /**
-           * Can be called to explicitly disable event listening
-           * for clicks and touches outside of this element.
-           */
-          disableOnClickOutside: function() {
-            var fn = this.__outsideClickHandler;
-            if (typeof document !== "undefined") {
-                var events = this.props.eventTypes || DEFAULT_EVENTS;
-                if (!events.forEach) { events = [events] };
-                events.forEach(function (eventName) {
-                document.removeEventListener(eventName, fn);
-                });
-            }
-          },
-
-          /**
-           * Pass-through render
-           */
-          render: function() {
-            var passedProps = this.props;
-            var props = { ref: 'instance' };
-            Object.keys(this.props).forEach(function(key) {
-                props[key] = passedProps[key];
-            });
-            return React.createElement(Component,  props);
+            return Component;
           }
+        },
+
+        /**
+         * Access the wrapped Component's instance.
+         */
+        getInstance: function() {
+          return this.refs.instance;
+        },
+
+        // this is given meaning in componentDidMount
+        __outsideClickHandler: function(evt) {},
+
+        /**
+         * Add click listeners to the current document,
+         * linked to this component's state.
+         */
+        componentDidMount: function() {
+          var instance = this.getInstance();
+          var clickOutsideAccessor = config && config.onClickOutside;
+          var clickOutsideHandler;
+
+          if(typeof clickOutsideAccessor === "function") {
+            clickOutsideHandler = clickOutsideAccessor(instance);
+            if(typeof clickOutsideHandler !== "function") {
+              throw new Error("Component lacks a function for processing outside click events specified by the onClickOutside parameter.");
+            }
+          } else {
+              if(typeof instance.handleClickOutside !== "function") {
+                throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
+              }
+              clickOutsideHandler = instance.handleClickOutside;
+          }
+
+          var fn = this.__outsideClickHandler = generateOutsideCheck(
+              ReactDOM.findDOMNode(instance),
+              clickOutsideHandler.bind(instance),
+              this.props.outsideClickIgnoreClass || IGNORE_CLASS,
+              this.props.preventDefault || false,
+              this.props.stopPropagation || false
+          );
+
+          var pos = registeredComponents.length;
+          registeredComponents.push(this);
+          handlers[pos] = fn;
+
+          // If there is a truthy disableOnClickOutside property for this
+          // component, don't immediately start listening for outside events.
+          if (!this.props.disableOnClickOutside) {
+              this.enableOnClickOutside();
+          }
+        },
+
+        /**
+        * Track for disableOnClickOutside props changes and enable/disable click outside
+        */
+        componentWillReceiveProps: function(nextProps) {
+          if (this.props.disableOnClickOutside && !nextProps.disableOnClickOutside) {
+              this.enableOnClickOutside();
+          } else if (!this.props.disableOnClickOutside && nextProps.disableOnClickOutside) {
+              this.disableOnClickOutside();
+          }
+        },
+
+        /**
+         * Remove the document's event listeners
+         */
+        componentWillUnmount: function() {
+          this.disableOnClickOutside();
+          this.__outsideClickHandler = false;
+          var pos = registeredComponents.indexOf(this);
+          if( pos>-1) {
+              // clean up so we don't leak memory
+              if (handlers[pos]) { handlers.splice(pos, 1); }
+              registeredComponents.splice(pos, 1);
+          }
+        },
+
+        /**
+         * Can be called to explicitly enable event listening
+         * for clicks and touches outside of this element.
+         */
+        enableOnClickOutside: function() {
+          var fn = this.__outsideClickHandler;
+          if (typeof document !== "undefined") {
+              var events = this.props.eventTypes || DEFAULT_EVENTS;
+              if (!events.forEach) { events = [events] };
+              events.forEach(function (eventName) {
+              document.addEventListener(eventName, fn);
+              });
+          }
+        },
+
+        /**
+         * Can be called to explicitly disable event listening
+         * for clicks and touches outside of this element.
+         */
+        disableOnClickOutside: function() {
+          var fn = this.__outsideClickHandler;
+          if (typeof document !== "undefined") {
+              var events = this.props.eventTypes || DEFAULT_EVENTS;
+              if (!events.forEach) { events = [events] };
+              events.forEach(function (eventName) {
+              document.removeEventListener(eventName, fn);
+              });
+          }
+        },
+
+        /**
+         * Pass-through render
+         */
+        render: function() {
+          var passedProps = this.props;
+          var props = { ref: 'instance' };
+          Object.keys(this.props).forEach(function(key) {
+              props[key] = passedProps[key];
+          });
+          return React.createElement(Component,  props);
+        }
       });
 
       // Add display name for React devtools
@@ -209,6 +207,17 @@
       }(Component, wrapComponentWithOnClickOutsideHandling));
 
       return wrapComponentWithOnClickOutsideHandling;
+    };
+
+    // The actual Component-wrapping HOC:
+    return function(configOrComponent) {
+      // Detect the legacy call
+      if (typeof configOrComponent === 'function'){
+        return hocBody(configOrComponent);
+      }
+
+      return function(Component) {
+        return hocBody(Component, configOrComponent);
       };
     };
   }

--- a/test/test.js
+++ b/test/test.js
@@ -27,38 +27,11 @@ describe('onclickoutside hoc', function() {
     }
   });
 
-  var BadComponent = React.createClass({
-    render: function() {
-      return React.createElement('div');
-    }
-  });
-
-  var CustomComponent = React.createClass({
-    getInitialState: function() {
-      return {
-        clickOutsideHandled: false
-      };
-    },
-
-    myOnClickHandler: function(event) {
-      if (event === undefined) {
-          throw new Error("event cannot be undefined");
-      }
-
-      this.setState({
-        clickOutsideHandled: true
-      });
-    },
-
-    render: function() {
-      return React.createElement('div');
-    }
-  });
+  var WrappedComponent = wrapComponent(Component);
 
   // tests
 
   it('should call handleClickOutside when clicking the document', function() {
-    var WrappedComponent = wrapComponent()(Component);
     var element = React.createElement(WrappedComponent);
     assert(element, "element can be created");
     var component = TestUtils.renderIntoDocument(element);
@@ -68,26 +41,14 @@ describe('onclickoutside hoc', function() {
     assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
   });
 
+
   it('should throw an error when a component without handleClickOutside(evt) is wrapped', function() {
-    try {
-      var bad = wrapComponent()(BadComponent);
-      assert(false, "component was wrapped, despite not implementing handleClickOutside(evt)");
-    } catch (e) {
-      assert(e, "component was not wrapped");
-    }
-  });
+    var BadComponent = React.createClass({
+      render: function() {
+        return React.createElement('div');
+      }
+    });
 
-  it('should call handleClickOutside when clicking the document using the legacy call convention', function() {
-    var element = React.createElement(wrapComponent(Component));
-    assert(element, "element can be created");
-    var component = TestUtils.renderIntoDocument(element);
-    assert(component, "component renders correctly");
-    document.dispatchEvent(new Event('mousedown'));
-    var instance = component.getInstance();
-    assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
-  });
-
-  it('should throw an error when a component without handleClickOutside(evt) is wrapped using legacy call convention', function() {
     try {
       var bad = wrapComponent(BadComponent);
       assert(false, "component was wrapped, despite not implementing handleClickOutside(evt)");
@@ -96,12 +57,33 @@ describe('onclickoutside hoc', function() {
     }
   });
 
+
   it('should call the specified handler when clicking the document', function() {
-    var WrappedWithCustomHandler = wrapComponent({
-      onClickOutside: function(instance) {
-        return instance.myOnClickHandler;
+    var CustomComponent = React.createClass({
+      getInitialState: function() {
+        return {
+          clickOutsideHandled: false
+        };
+      },
+
+      myOnClickHandler: function(event) {
+        if (event === undefined) {
+            throw new Error("event cannot be undefined");
+        }
+
+        this.setState({
+          clickOutsideHandled: true
+        });
+      },
+
+      render: function() {
+        return React.createElement('div');
       }
-    })(CustomComponent);
+    });
+
+    var WrappedWithCustomHandler = wrapComponent(CustomComponent, function(instance) {
+      return instance.myOnClickHandler;
+    });
 
     var element = React.createElement(WrappedWithCustomHandler);
     assert(element, "element can be created");
@@ -120,32 +102,12 @@ describe('onclickoutside hoc', function() {
     });
 
     try {
-      var bad = wrapComponent({
-        onClickOutside: function(instance){
+      var bad = wrapComponent(BadComponent, function(instance){
           return instance.nonExistentMethod;
-        }
-      })(BadComponent);
+      });
       assert(false, "component was wrapped, despite not implementing the custom handler");
     } catch (e) {
       assert(e, "component was not wrapped");
     }
-  });
-
-  it('should allow for partial application', function() {
-    var partiallyAppliedWrapper = wrapComponent({
-      onClickOutside: function(instance) {
-        return instance.myOnClickHandler;
-      }
-    });
-
-    var WrappedWithCustomHandler = partiallyAppliedWrapper(CustomComponent);
-
-    var element = React.createElement(WrappedWithCustomHandler);
-    assert(element, "element can be created");
-    var component = TestUtils.renderIntoDocument(element);
-    assert(component, "component renders correctly");
-    document.dispatchEvent(new Event('mousedown'));
-    var instance = component.getInstance();
-    assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -27,11 +27,38 @@ describe('onclickoutside hoc', function() {
     }
   });
 
-  var WrappedComponent = wrapComponent()(Component);
+  var BadComponent = React.createClass({
+    render: function() {
+      return React.createElement('div');
+    }
+  });
+
+  var CustomComponent = React.createClass({
+    getInitialState: function() {
+      return {
+        clickOutsideHandled: false
+      };
+    },
+
+    myOnClickHandler: function(event) {
+      if (event === undefined) {
+          throw new Error("event cannot be undefined");
+      }
+
+      this.setState({
+        clickOutsideHandled: true
+      });
+    },
+
+    render: function() {
+      return React.createElement('div');
+    }
+  });
 
   // tests
 
   it('should call handleClickOutside when clicking the document', function() {
+    var WrappedComponent = wrapComponent()(Component);
     var element = React.createElement(WrappedComponent);
     assert(element, "element can be created");
     var component = TestUtils.renderIntoDocument(element);
@@ -41,14 +68,7 @@ describe('onclickoutside hoc', function() {
     assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
   });
 
-
   it('should throw an error when a component without handleClickOutside(evt) is wrapped', function() {
-    var BadComponent = React.createClass({
-      render: function() {
-        return React.createElement('div');
-      }
-    });
-
     try {
       var bad = wrapComponent()(BadComponent);
       assert(false, "component was wrapped, despite not implementing handleClickOutside(evt)");
@@ -57,30 +77,26 @@ describe('onclickoutside hoc', function() {
     }
   });
 
+  it('should call handleClickOutside when clicking the document using the legacy call convention', function() {
+    var element = React.createElement(wrapComponent(Component));
+    assert(element, "element can be created");
+    var component = TestUtils.renderIntoDocument(element);
+    assert(component, "component renders correctly");
+    document.dispatchEvent(new Event('mousedown'));
+    var instance = component.getInstance();
+    assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
+  });
+
+  it('should throw an error when a component without handleClickOutside(evt) is wrapped using legacy call convention', function() {
+    try {
+      var bad = wrapComponent(BadComponent);
+      assert(false, "component was wrapped, despite not implementing handleClickOutside(evt)");
+    } catch (e) {
+      assert(e, "component was not wrapped");
+    }
+  });
 
   it('should call the specified handler when clicking the document', function() {
-    var CustomComponent = React.createClass({
-      getInitialState: function() {
-        return {
-          clickOutsideHandled: false
-        };
-      },
-
-      myOnClickHandler: function(event) {
-        if (event === undefined) {
-            throw new Error("event cannot be undefined");
-        }
-
-        this.setState({
-          clickOutsideHandled: true
-        });
-      },
-
-      render: function() {
-        return React.createElement('div');
-      }
-    });
-
     var WrappedWithCustomHandler = wrapComponent({
       onClickOutside: function(instance) {
         return instance.myOnClickHandler;
@@ -113,5 +129,23 @@ describe('onclickoutside hoc', function() {
     } catch (e) {
       assert(e, "component was not wrapped");
     }
+  });
+
+  it('should allow for partial application', function() {
+    var partiallyAppliedWrapper = wrapComponent({
+      onClickOutside: function(instance) {
+        return instance.myOnClickHandler;
+      }
+    });
+
+    var WrappedWithCustomHandler = partiallyAppliedWrapper(CustomComponent);
+
+    var element = React.createElement(WrappedWithCustomHandler);
+    assert(element, "element can be created");
+    var component = TestUtils.renderIntoDocument(element);
+    assert(component, "component renders correctly");
+    document.dispatchEvent(new Event('mousedown'));
+    var instance = component.getInstance();
+    assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('onclickoutside hoc', function() {
     }
   });
 
-  var WrappedComponent = wrapComponent(Component);
+  var WrappedComponent = wrapComponent()(Component);
 
   // tests
 
@@ -50,7 +50,7 @@ describe('onclickoutside hoc', function() {
     });
 
     try {
-      var bad = wrapComponent(BadComponent);
+      var bad = wrapComponent()(BadComponent);
       assert(false, "component was wrapped, despite not implementing handleClickOutside(evt)");
     } catch (e) {
       assert(e, "component was not wrapped");
@@ -81,9 +81,11 @@ describe('onclickoutside hoc', function() {
       }
     });
 
-    var WrappedWithCustomHandler = wrapComponent(CustomComponent, function(instance) {
-      return instance.myOnClickHandler;
-    });
+    var WrappedWithCustomHandler = wrapComponent({
+      onClickOutside: function(instance) {
+        return instance.myOnClickHandler;
+      }
+    })(CustomComponent);
 
     var element = React.createElement(WrappedWithCustomHandler);
     assert(element, "element can be created");
@@ -102,9 +104,11 @@ describe('onclickoutside hoc', function() {
     });
 
     try {
-      var bad = wrapComponent(BadComponent, function(instance){
+      var bad = wrapComponent({
+        onClickOutside: function(instance){
           return instance.nonExistentMethod;
-      });
+        }
+      })(BadComponent);
       assert(false, "component was wrapped, despite not implementing the custom handler");
     } catch (e) {
       assert(e, "component was not wrapped");

--- a/test/test.js
+++ b/test/test.js
@@ -81,8 +81,10 @@ describe('onclickoutside hoc', function() {
       }
     });
 
-    var WrappedWithCustomHandler = wrapComponent(CustomComponent, function(instance) {
-      return instance.myOnClickHandler;
+    var WrappedWithCustomHandler = wrapComponent(CustomComponent, {
+      handleClickOutside: function (instance) {
+        return instance.myOnClickHandler;
+      }
     });
 
     var element = React.createElement(WrappedWithCustomHandler);
@@ -102,8 +104,10 @@ describe('onclickoutside hoc', function() {
     });
 
     try {
-      var bad = wrapComponent(BadComponent, function(instance){
+      var bad = wrapComponent(BadComponent, {
+        handleClickOutside: function (instance) {
           return instance.nonExistentMethod;
+        }
       });
       assert(false, "component was wrapped, despite not implementing the custom handler");
     } catch (e) {

--- a/test/test.js
+++ b/test/test.js
@@ -56,4 +56,58 @@ describe('onclickoutside hoc', function() {
       assert(e, "component was not wrapped");
     }
   });
+
+
+  it('should call the specified handler when clicking the document', function() {
+    var CustomComponent = React.createClass({
+      getInitialState: function() {
+        return {
+          clickOutsideHandled: false
+        };
+      },
+
+      myOnClickHandler: function(event) {
+        if (event === undefined) {
+            throw new Error("event cannot be undefined");
+        }
+
+        this.setState({
+          clickOutsideHandled: true
+        });
+      },
+
+      render: function() {
+        return React.createElement('div');
+      }
+    });
+
+    var WrappedWithCustomHandler = wrapComponent(CustomComponent, function(instance) {
+      return instance.myOnClickHandler;
+    });
+
+    var element = React.createElement(WrappedWithCustomHandler);
+    assert(element, "element can be created");
+    var component = TestUtils.renderIntoDocument(element);
+    assert(component, "component renders correctly");
+    document.dispatchEvent(new Event('mousedown'));
+    var instance = component.getInstance();
+    assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
+  });
+
+  it('should throw an error when a custom handler is specified, but the component does not implement it', function() {
+    var BadComponent = React.createClass({
+      render: function() {
+        return React.createElement('div');
+      }
+    });
+
+    try {
+      var bad = wrapComponent(BadComponent, function(instance){
+          return instance.nonExistentMethod;
+      });
+      assert(false, "component was wrapped, despite not implementing the custom handler");
+    } catch (e) {
+      assert(e, "component was not wrapped");
+    }
+  });
 });


### PR DESCRIPTION
Fixes #115.

The implementation maintains compatibility with the previous call convention (as demonstrated in the tests), so it should not break semver.