### PR TITLE
fallback to call handleClickOutside from props, fix #98

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 2

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,32 @@
+{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "amd": true,
+    "mocha": true
+  },
+  "extends": "eslint:recommended",
+  "globals": {
+    "React": true,
+    "ReactDOM": true
+  },
+  "rules": {
+    "indent": [
+      "error",
+      2
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "no-console": 0
+  }
+}

--- a/index.js
+++ b/index.js
@@ -107,10 +107,13 @@
               throw new Error("Component lacks a function for processing outside click events specified by the handleClickOutside config option.");
             }
           } else {
-              if(typeof instance.handleClickOutside !== "function") {
-                throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
+            if(typeof instance.handleClickOutside === "function") {
+              clickOutsideHandler = instance.handleClickOutside;
+            } else if(typeof instance.props.handleClickOutside === "function") {
+              clickOutsideHandler = instance.props.handleClickOutside;
+						} else {
+              throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
             }
-            clickOutsideHandler = instance.handleClickOutside;
           }
 
           var fn = this.__outsideClickHandler = generateOutsideCheck(

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * A higher-order-component for handling onClickOutside for React components.
  */
 (function(root) {
-  "use strict";
+  'use strict';
 
   // administrative
   var registeredComponents = [];
@@ -57,7 +57,7 @@
       // outside", as it cannot be known whether it was outside.
       if(current !== document) return;
       eventHandler(evt);
-    }
+    };
   };
 
 
@@ -91,7 +91,7 @@
         },
 
         // this is given meaning in componentDidMount
-        __outsideClickHandler: function(evt) {},
+        __outsideClickHandler: function() {},
 
         /**
          * Add click listeners to the current document,
@@ -101,18 +101,18 @@
           var instance = this.getInstance();
           var clickOutsideHandler;
 
-          if(config && typeof config.handleClickOutside === "function") {
+          if(config && typeof config.handleClickOutside === 'function') {
             clickOutsideHandler = config.handleClickOutside(instance);
-            if(typeof clickOutsideHandler !== "function") {
-              throw new Error("Component lacks a function for processing outside click events specified by the handleClickOutside config option.");
+            if(typeof clickOutsideHandler !== 'function') {
+              throw new Error('Component lacks a function for processing outside click events specified by the handleClickOutside config option.');
             }
           } else {
-            if(typeof instance.handleClickOutside === "function") {
+            if(typeof instance.handleClickOutside === 'function') {
               clickOutsideHandler = instance.handleClickOutside;
-            } else if(typeof instance.props.handleClickOutside === "function") {
+            } else if(typeof instance.props.handleClickOutside === 'function') {
               clickOutsideHandler = instance.props.handleClickOutside;
-						} else {
-              throw new Error("Component lacks a handleClickOutside(event) function for processing outside click events.");
+            } else {
+              throw new Error('Component lacks a handleClickOutside(event) function for processing outside click events.');
             }
           }
 
@@ -167,9 +167,9 @@
          */
         enableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
-          if (typeof document !== "undefined") {
+          if (typeof document !== 'undefined') {
             var events = this.props.eventTypes || DEFAULT_EVENTS;
-            if (!events.forEach) { events = [events] };
+            if (!events.forEach) { events = [events]; }
             events.forEach(function (eventName) {
               document.addEventListener(eventName, fn);
             });
@@ -182,9 +182,9 @@
          */
         disableOnClickOutside: function() {
           var fn = this.__outsideClickHandler;
-          if (typeof document !== "undefined") {
+          if (typeof document !== 'undefined') {
             var events = this.props.eventTypes || DEFAULT_EVENTS;
-            if (!events.forEach) { events = [events] };
+            if (!events.forEach) { events = [events]; }
             events.forEach(function (eventName) {
               document.removeEventListener(eventName, fn);
             });
@@ -206,7 +206,7 @@
 
       // Add display name for React devtools
       (function bindWrappedComponentName(c, wrapper) {
-        var componentName = c.displayName || c.name || 'Component'
+        var componentName = c.displayName || c.name || 'Component';
         wrapper.displayName = 'OnClickOutside(' + componentName + ')';
       }(Component, wrapComponentWithOnClickOutsideHandling));
 

--- a/package.json
+++ b/package.json
@@ -22,13 +22,17 @@
     "url": "https://github.com/Pomax/react-onclickoutside/issues"
   },
   "scripts": {
-    "test": "karma start test/karma.conf.js --single-run"
+    "test": "karma start test/karma.conf.js --single-run",
+    "lint": "eslint .",
+    "precommit": "npm run lint"
   },
   "dependencies": {
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "eslint": "^3.3.1",
+    "husky": "^0.11.6",
     "karma": "^0.13.22",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.2.2",

--- a/test/browser/testit.js
+++ b/test/browser/testit.js
@@ -1,12 +1,13 @@
 /**
  * Human-triggered for now, this should become a normal phantom test instead
  */
+/* global onClickOutside */
 var Nested = React.createClass({
   getInitialState: function() {
     return { highlight: false };
   },
 
-  handleClickOutside: function(evt) {
+  handleClickOutside: function() {
     this.setState({ highlight: false });
   },
 
@@ -16,8 +17,8 @@ var Nested = React.createClass({
   },
 
   render: function() {
-    var className = "concentric" + (this.state.highlight? " highlight" : '');
-    return React.createElement("div", {
+    var className = 'concentric' + (this.state.highlight? ' highlight' : '');
+    return React.createElement('div', {
       className: className,
       children: this.props.children,
       onClick: this.highlight
@@ -38,7 +39,7 @@ var App = React.createClass({
         children: React.createElement(Nested, {
           id: 3,
           stopPropagation: true,
-          children: React.createElement("div", { className: "label", children: ["test"] })
+          children: React.createElement('div', { className: 'label', children: ['test'] })
         })
       })
     });

--- a/test/test.js
+++ b/test/test.js
@@ -57,7 +57,6 @@ describe('onclickoutside hoc', function() {
     }
   });
 
-
   it('should call the specified handler when clicking the document', function() {
     var CustomComponent = React.createClass({
       getInitialState: function() {
@@ -88,12 +87,41 @@ describe('onclickoutside hoc', function() {
     });
 
     var element = React.createElement(WrappedWithCustomHandler);
-    assert(element, "element can be created");
+		assert(element, "element can be created");
     var component = TestUtils.renderIntoDocument(element);
     assert(component, "component renders correctly");
     document.dispatchEvent(new Event('mousedown'));
     var instance = component.getInstance();
     assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
+  });
+
+	it('should fallback to call component.props.handleClickOutside when no component.handleClickOutside is defined', function() {
+		var StatelessComponent = React.createClass({
+			render: function() {
+				return React.createElement('div');
+			}
+		});
+    var clickOutsideHandled = false;
+		var WrappedStatelessComponent = wrapComponent(StatelessComponent);
+		var element = React.createElement(
+			WrappedStatelessComponent,
+			{
+				handleClickOutside: function(event) {
+					if (event === undefined) {
+		          throw new Error("event cannot be undefined");
+		      }
+
+		      clickOutsideHandled = true;
+				}
+			}
+		);
+
+    assert(element, "element can be created");
+    var component = TestUtils.renderIntoDocument(element);
+    assert(component, "component renders correctly");
+    document.dispatchEvent(new Event('mousedown'));
+    var instance = component.getInstance();
+    assert(clickOutsideHandled, "clickOutsideHandled got flipped");
   });
 
   it('should throw an error when a custom handler is specified, but the component does not implement it', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 var React = require('react');
-var ReactDOM = require('react-dom');
 var TestUtils = require('react-addons-test-utils');
 var wrapComponent = require('../index');
+var assert = require('chai').assert;
 
 describe('onclickoutside hoc', function() {
 
@@ -14,7 +14,7 @@ describe('onclickoutside hoc', function() {
 
     handleClickOutside: function(event) {
       if (event === undefined) {
-          throw new Error("event cannot be undefined");
+        throw new Error('event cannot be undefined');
       }
 
       this.setState({
@@ -33,12 +33,12 @@ describe('onclickoutside hoc', function() {
 
   it('should call handleClickOutside when clicking the document', function() {
     var element = React.createElement(WrappedComponent);
-    assert(element, "element can be created");
+    assert(element, 'element can be created');
     var component = TestUtils.renderIntoDocument(element);
-    assert(component, "component renders correctly");
+    assert(component, 'component renders correctly');
     document.dispatchEvent(new Event('mousedown'));
     var instance = component.getInstance();
-    assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
+    assert(instance.state.clickOutsideHandled, 'clickOutsideHandled got flipped');
   });
 
 
@@ -50,10 +50,10 @@ describe('onclickoutside hoc', function() {
     });
 
     try {
-      var bad = wrapComponent(BadComponent);
-      assert(false, "component was wrapped, despite not implementing handleClickOutside(evt)");
+      wrapComponent(BadComponent);
+      assert(false, 'component was wrapped, despite not implementing handleClickOutside(evt)');
     } catch (e) {
-      assert(e, "component was not wrapped");
+      assert(e, 'component was not wrapped');
     }
   });
 
@@ -67,7 +67,7 @@ describe('onclickoutside hoc', function() {
 
       myOnClickHandler: function(event) {
         if (event === undefined) {
-            throw new Error("event cannot be undefined");
+          throw new Error('event cannot be undefined');
         }
 
         this.setState({
@@ -87,41 +87,41 @@ describe('onclickoutside hoc', function() {
     });
 
     var element = React.createElement(WrappedWithCustomHandler);
-		assert(element, "element can be created");
+    assert(element, 'element can be created');
     var component = TestUtils.renderIntoDocument(element);
-    assert(component, "component renders correctly");
+    assert(component, 'component renders correctly');
     document.dispatchEvent(new Event('mousedown'));
     var instance = component.getInstance();
-    assert(instance.state.clickOutsideHandled, "clickOutsideHandled got flipped");
+    assert(instance.state.clickOutsideHandled, 'clickOutsideHandled got flipped');
   });
 
-	it('should fallback to call component.props.handleClickOutside when no component.handleClickOutside is defined', function() {
-		var StatelessComponent = React.createClass({
-			render: function() {
-				return React.createElement('div');
-			}
-		});
+  it('should fallback to call component.props.handleClickOutside when no component.handleClickOutside is defined', function() {
+    var StatelessComponent = React.createClass({
+      render: function() {
+        return React.createElement('div');
+      }
+    });
     var clickOutsideHandled = false;
-		var WrappedStatelessComponent = wrapComponent(StatelessComponent);
-		var element = React.createElement(
+    var WrappedStatelessComponent = wrapComponent(StatelessComponent);
+    var element = React.createElement(
 			WrappedStatelessComponent,
-			{
-				handleClickOutside: function(event) {
-					if (event === undefined) {
-		          throw new Error("event cannot be undefined");
-		      }
+      {
+        handleClickOutside: function(event) {
+          if (event === undefined) {
+            throw new Error('event cannot be undefined');
+          }
 
-		      clickOutsideHandled = true;
-				}
-			}
+          clickOutsideHandled = true;
+        }
+      }
 		);
 
-    assert(element, "element can be created");
+    assert(element, 'element can be created');
     var component = TestUtils.renderIntoDocument(element);
-    assert(component, "component renders correctly");
+    assert(component, 'component renders correctly');
     document.dispatchEvent(new Event('mousedown'));
-    var instance = component.getInstance();
-    assert(clickOutsideHandled, "clickOutsideHandled got flipped");
+    component.getInstance();
+    assert(clickOutsideHandled, 'clickOutsideHandled got flipped');
   });
 
   it('should throw an error when a custom handler is specified, but the component does not implement it', function() {
@@ -132,14 +132,14 @@ describe('onclickoutside hoc', function() {
     });
 
     try {
-      var bad = wrapComponent(BadComponent, {
+      wrapComponent(BadComponent, {
         handleClickOutside: function (instance) {
           return instance.nonExistentMethod;
         }
       });
-      assert(false, "component was wrapped, despite not implementing the custom handler");
+      assert(false, 'component was wrapped, despite not implementing the custom handler');
     } catch (e) {
-      assert(e, "component was not wrapped");
+      assert(e, 'component was not wrapped');
     }
   });
 });


### PR DESCRIPTION
Quick fix for #98, simply fallback to call `props.handleClickOutside` instead.
Also there is a simple test.