### PR TITLE
add test for binding issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,12 +108,20 @@
               throw new Error('Component lacks a function for processing outside click events specified by the handleClickOutside config option.');
             }
           } else if(typeof instance.handleClickOutside === 'function') {
-            clickOutsideHandler = instance.handleClickOutside;
+            if (React.Component.prototype.isPrototypeOf(instance)) {
+              clickOutsideHandler = instance.handleClickOutside.bind(instance);
+            } else {
+              clickOutsideHandler = instance.handleClickOutside;
+            }
           } else if(typeof instance.props.handleClickOutside === 'function') {
-            clickOutsideHandler = instance.props.handleClickOutside;
+            if (React.Component.prototype.isPrototypeOf(instance)) {
+              clickOutsideHandler = instance.props.handleClickOutside.bind(instance);
+            } else {
+              clickOutsideHandler = instance.props.handleClickOutside;
+            }
           } else {
             throw new Error('Component lacks a handleClickOutside(event) function for processing outside click events.');
-          }             
+          }
 
           var fn = this.__outsideClickHandler = generateOutsideCheck(
             ReactDOM.findDOMNode(instance),

--- a/index.js
+++ b/index.js
@@ -114,11 +114,7 @@
               clickOutsideHandler = instance.handleClickOutside;
             }
           } else if(typeof instance.props.handleClickOutside === 'function') {
-            if (React.Component.prototype.isPrototypeOf(instance)) {
-              clickOutsideHandler = instance.props.handleClickOutside.bind(instance);
-            } else {
-              clickOutsideHandler = instance.props.handleClickOutside;
-            }
+            clickOutsideHandler = instance.props.handleClickOutside;
           } else {
             throw new Error('Component lacks a handleClickOutside(event) function for processing outside click events.');
           }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.14.0",
     "chai": "^3.5.0",
     "eslint": "^3.4.0",
     "karma": "^0.13.22",
+    "karma-babel-preprocessor": "^6.0.1",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.2.2",
     "karma-phantomjs-launcher": "^1.0.0",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
+}

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -8,7 +8,20 @@ module.exports = function(config) {
     frameworks: ['mocha', 'chai'],
 
     preprocessors: {
-      'test.js': ['webpack']
+      'test.js': ['webpack', 'babel']
+    },
+
+    babelPreprocessor: {
+      options: {
+        presets: ['es2015'],
+        sourceMap: 'inline'
+      },
+      filename: function (file) {
+        return file.originalPath.replace(/\.js$/, '.es5.js');
+      },
+      sourceFileName: function (file) {
+        return file.originalPath;
+      }
     },
 
     reporters: ['spec'],
@@ -22,7 +35,8 @@ module.exports = function(config) {
       require('karma-mocha'),
       require('karma-chai'),
       require('karma-phantomjs-launcher'),
-      require('karma-spec-reporter')
+      require('karma-spec-reporter'),
+      require('karma-babel-preprocessor')
     ],
 
     browsers: ['PhantomJS']

--- a/test/test.js
+++ b/test/test.js
@@ -66,41 +66,160 @@ describe('onclickoutside hoc', function() {
       assert(e, 'component was not wrapped');
     }
   });
+  
 
+  describe('with instance method', function() {
+    it('and class inheritance, should call the specified handler when clicking the document', function() {
+      class Component extends React.Component {
+        constructor(...args) {
+          super(...args);
+          this.state = {
+            clickOutsideHandled: false
+          };
+        }
 
-  it('should call the specified handler when clicking the document', function() {
-    class Component extends React.Component {
-      constructor(...args) {
-        super(...args);
-        this.state = {
-          clickOutsideHandled: false
-        };
+        handleClickOutside (event) {
+          if (event === undefined) {
+            throw new Error('event cannot be undefined');
+          }
+
+          this.setState({
+            clickOutsideHandled: true
+          });
+        }
+
+        render() {
+          return React.createElement('div');
+        }
       }
 
-      handleClickOutside (event) {
+      var WrappedWithCustomHandler = wrapComponent(Component);
+
+      var element = React.createElement(WrappedWithCustomHandler);
+      assert(element, 'element can be created');
+      var component = TestUtils.renderIntoDocument(element);
+      assert(component, 'component renders correctly');
+      document.dispatchEvent(new Event('mousedown'));
+      var instance = component.getInstance();
+      assert(instance.state.clickOutsideHandled, 'clickOutsideHandled got flipped');
+    });
+
+
+    it('and createClass method, should call the specified handler when clicking the document', function() {
+      var Component = React.createClass({
+        getInitialState: function() {
+          return {
+            clickOutsideHandled: false
+          };
+        },
+ 
+        handleClickOutside: function(event) {
+          if (event === undefined) {
+            throw new Error('event cannot be undefined');
+          }
+  
+          this.setState({
+            clickOutsideHandled: true
+          });
+        },
+   
+        render: function() {
+          return React.createElement('div');
+        }
+      });
+
+      var WrappedWithCustomHandler = wrapComponent(Component);
+
+      var element = React.createElement(WrappedWithCustomHandler);
+      assert(element, 'element can be created');
+      var component = TestUtils.renderIntoDocument(element);
+      assert(component, 'component renders correctly');
+      document.dispatchEvent(new Event('mousedown'));
+      var instance = component.getInstance();
+      assert(instance.state.clickOutsideHandled, 'clickOutsideHandled got flipped');
+    });
+  });
+
+
+  describe('with property', function() {
+    it('and class inheritance, should call the specified handler when clicking the document', function() {
+      class Component extends React.Component {
+        render() {
+          return React.createElement('div');
+        }
+      }
+
+      var clickOutsideHandled = false;
+      var handleClickOutside = function(event) {
         if (event === undefined) {
           throw new Error('event cannot be undefined');
         }
 
-        this.setState({
-          clickOutsideHandled: true
-        });
-      }
+        clickOutsideHandled = true;
+      };
 
-      render() {
+      var WrappedWithCustomHandler = wrapComponent(Component);
+
+      var element = React.createElement(WrappedWithCustomHandler, { handleClickOutside: handleClickOutside });
+      assert(element, 'element can be created');
+      var component = TestUtils.renderIntoDocument(element);
+      assert(component, 'component renders correctly');
+      document.dispatchEvent(new Event('mousedown'));
+      assert(clickOutsideHandled, 'clickOutsideHandled got flipped');
+    });
+
+
+    it('and createClass method, should call the specified handler when clicking the document', function() {
+      var Component = React.createClass({
+        render: function() {
+          return React.createElement('div');
+        }
+      });
+
+      var clickOutsideHandled = false;
+      var handleClickOutside = function(event) {
+        if (event === undefined) {
+          throw new Error('event cannot be undefined');
+        }
+
+        clickOutsideHandled = true;
+      };
+
+      var WrappedWithCustomHandler = wrapComponent(Component);
+
+      var element = React.createElement(WrappedWithCustomHandler, { handleClickOutside: handleClickOutside });
+      assert(element, 'element can be created');
+      var component = TestUtils.renderIntoDocument(element);
+      assert(component, 'component renders correctly');
+      document.dispatchEvent(new Event('mousedown'));
+      assert(clickOutsideHandled, 'clickOutsideHandled got flipped');
+    });
+
+    
+    // ToDo: Does not work
+    it.skip('and stateless function, should call the specified handler when clicking the document', function() {
+      var Component = function() {
         return React.createElement('div');
-      }
-    }
+      };
 
-    var WrappedWithCustomHandler = wrapComponent(Component);
+      var clickOutsideHandled = false;
+      var handleClickOutside = function(event) {
+        if (event === undefined) {
+          throw new Error('event cannot be undefined');
+        }
 
-    var element = React.createElement(WrappedWithCustomHandler);
-    assert(element, 'element can be created');
-    var component = TestUtils.renderIntoDocument(element);
-    assert(component, 'component renders correctly');
-    document.dispatchEvent(new Event('mousedown'));
-    var instance = component.getInstance();
-    assert(instance.state.clickOutsideHandled, 'clickOutsideHandled got flipped');
+        clickOutsideHandled = true;
+      };
+
+      var WrappedWithCustomHandler = wrapComponent(Component);
+
+      var element = React.createElement(WrappedWithCustomHandler, { handleClickOutside: handleClickOutside });
+      assert(element, 'element can be created');
+      var component = TestUtils.renderIntoDocument(element);
+      assert(component, 'component renders correctly');
+      document.dispatchEvent(new Event('mousedown'));
+      assert(clickOutsideHandled, 'clickOutsideHandled got flipped');
+    });
   });
 
 
@@ -145,6 +264,7 @@ describe('onclickoutside hoc', function() {
     document.dispatchEvent(new Event('mousedown'));
     assert(instance.state.timesHandlerCalled === 2, 'handleClickOutside called after enableOnClickOutside()');
   });
+
 
   it('should fallback to call component.props.handleClickOutside when no component.handleClickOutside is defined', function() {
     var StatelessComponent = React.createClass({

--- a/test/test.js
+++ b/test/test.js
@@ -69,14 +69,15 @@ describe('onclickoutside hoc', function() {
 
 
   it('should call the specified handler when clicking the document', function() {
-    var Component = React.createClass({
-      getInitialState: function() {
-        return {
+    class Component extends React.Component {
+      constructor(...args) {
+        super(...args);
+        this.state = {
           clickOutsideHandled: false
         };
-      },
+      }
 
-      myOnClickHandler: function(event) {
+      handleClickOutside (event) {
         if (event === undefined) {
           throw new Error('event cannot be undefined');
         }
@@ -84,18 +85,14 @@ describe('onclickoutside hoc', function() {
         this.setState({
           clickOutsideHandled: true
         });
-      },
+      }
 
-      render: function() {
+      render() {
         return React.createElement('div');
       }
-    });
+    }
 
-    var WrappedWithCustomHandler = wrapComponent(Component, {
-      handleClickOutside: function (instance) {
-        return instance.myOnClickHandler;
-      }
-    });
+    var WrappedWithCustomHandler = wrapComponent(Component);
 
     var element = React.createElement(WrappedWithCustomHandler);
     assert(element, 'element can be created');


### PR DESCRIPTION
This was a bit more complex than anticipated, because I had to add babel to reproduce the issue, but this test will fail if the regression fixed by #125 comes back.

This also brings to the forefront the difference between components created by inheritance, and components created by createClass. ~~The re-binding will give an error on the latter. Not sure what a long term solution is.~~ This can be fixed by looking at the prototype of the element.