### PR TITLE
Remove ref for stateless components

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@
          * Access the wrapped Component's instance.
          */
         getInstance: function() {
-          return this.refs.instance;
+          return Component.prototype.isReactComponent ? this.refs.instance : this;
         },
 
         // this is given meaning in componentDidMount
@@ -207,10 +207,12 @@
           Object.keys(this.props).forEach(function(key) {
             props[key] = passedProps[key];
           });
-          props.ref = 'instance';
+          if (Component.prototype.isReactComponent) {
+            props.ref = 'instance';
+          }
           props.disableOnClickOutside = this.disableOnClickOutside;
           props.enableOnClickOutside = this.enableOnClickOutside;
-          return React.createElement(Component,  props);
+          return React.createElement(Component, props);
         }
       });
 

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,7 @@ describe('onclickoutside hoc', function() {
       assert(e, 'component was not wrapped');
     }
   });
-  
+
 
   describe('with instance method', function() {
     it('and class inheritance, should call the specified handler when clicking the document', function() {
@@ -112,17 +112,17 @@ describe('onclickoutside hoc', function() {
             clickOutsideHandled: false
           };
         },
- 
+
         handleClickOutside: function(event) {
           if (event === undefined) {
             throw new Error('event cannot be undefined');
           }
-  
+
           this.setState({
             clickOutsideHandled: true
           });
         },
-   
+
         render: function() {
           return React.createElement('div');
         }
@@ -195,9 +195,8 @@ describe('onclickoutside hoc', function() {
       assert(clickOutsideHandled, 'clickOutsideHandled got flipped');
     });
 
-    
-    // ToDo: Does not work
-    it.skip('and stateless function, should call the specified handler when clicking the document', function() {
+
+    it('and stateless function, should call the specified handler when clicking the document', function() {
       var Component = function() {
         return React.createElement('div');
       };


### PR DESCRIPTION
Stateless components don't support refs, so this
uses the props from the wrapper component instead.
`isReactComponent` isn't documented, but seems to
work for both ES6 classes and components created
with `React.createClass`.

Fixes #127