### PR TITLE
Remove unused dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "lint": "eslint index.js ./test",
     "precommit": "npm run lint"
   },
-  "dependencies": {
-    "object-assign": "^4.0.1"
-  },
   "devDependencies": {
     "babel-preset-es2015": "^6.14.0",
     "chai": "^3.5.0",


### PR DESCRIPTION
The object-assign dependency was not being used and can thus be safely removed.