### PR TITLE
Add option to exclude scrollbar from outside check

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,10 +52,17 @@
   };
 
   /**
+   * Check if the browser scrollbar was clicked
+   */
+  var clickedScrollbar = function(evt) {
+    return document.documentElement.clientWidth <= evt.clientX;
+  };
+
+  /**
    * Generate the event handler that checks whether a clicked DOM node
    * is inside of, or lives outside of, our Component's node tree.
    */
-  var generateOutsideCheck = function(componentNode, componentInstance, eventHandler, ignoreClass, preventDefault, stopPropagation) {
+  var generateOutsideCheck = function(componentNode, componentInstance, eventHandler, ignoreClass, excludeScrollbar, preventDefault, stopPropagation) {
     return function(evt) {
       if (preventDefault) {
         evt.preventDefault();
@@ -64,7 +71,7 @@
         evt.stopPropagation();
       }
       var current = evt.target;
-      if(findHighest(current, componentNode, ignoreClass) !== document) {
+      if((excludeScrollbar && clickedScrollbar(evt)) || (findHighest(current, componentNode, ignoreClass) !== document)) {
         return;
       }
       eventHandler(evt);
@@ -161,6 +168,7 @@
             instance,
             clickOutsideHandler,
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
+            this.props.excludeScrollbar || false,
             this.props.preventDefault || false,
             this.props.stopPropagation || false
           );
@@ -242,7 +250,9 @@
           var passedProps = this.props;
           var props = {};
           Object.keys(this.props).forEach(function(key) {
-            props[key] = passedProps[key];
+            if (key !== 'excludeScrollbar') {
+              props[key] = passedProps[key];
+            }
           });
           if (Component.prototype.isReactComponent) {
             props.ref = 'instance';


### PR DESCRIPTION
This PR addresses https://github.com/Pomax/react-onclickoutside/issues/130 by allowing an option to exclude the browser scrollbar from the click outside check.

The default behavior would be the same as current behavior.