### PR TITLE
Reset handler on update

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,14 +162,19 @@
               'for that decision.'
             ].join(' '));
           }
-          
+
           if (this.__node === componentNode) {
             /*
-              If the node hasnt changed after an update, then return
+              If the node hasnt changed after an update, then return.
             */
             return;
+          } else {
+            /*
+              Disable existing click handlers because we will set new ones.
+            */
+            this.disableOnClickOutside();
           }
-          
+
           this.__node = componentNode;
 
           var fn = this.__outsideClickHandler = generateOutsideCheck(
@@ -181,12 +186,12 @@
             this.props.preventDefault || false,
             this.props.stopPropagation || false
           );
-          
+
           if (!this.__pos) {
             this.__pos = registeredComponents.length;
             registeredComponents.push(this);
           }
-         
+
           handlers[this.__pos] = fn;
 
           // If there is a truthy disableOnClickOutside property for this
@@ -195,14 +200,14 @@
             this.enableOnClickOutside();
           }
         },
-        
+
         componentDidMount: function() {
           this.__setOutsideClickHandler();
         },
-        
+
         componentDidUpdate: function(prevProps) {
           this.__setOutsideClickHandler();
-          
+
           if (this.props.disableOnClickOutside && !prevProps.disableOnClickOutside) {
             this.disableOnClickOutside();
           } else if (!this.props.disableOnClickOutside && prevProps.disableOnClickOutside) {

--- a/index.js
+++ b/index.js
@@ -199,17 +199,11 @@
         componentDidMount: function() {
           this.__setOutsideClickHandler();
         },
-        /**
-        * Track for disableOnClickOutside props changes and enable/disable click outside
-        */
-        componentWillReceiveProps: function(nextProps) {
-         
-        },
         
         componentDidUpdate: function(prevProps) {
           this.__setOutsideClickHandler();
           
-           if (this.props.disableOnClickOutside && !prevProps.disableOnClickOutside) {
+          if (this.props.disableOnClickOutside && !prevProps.disableOnClickOutside) {
             this.disableOnClickOutside();
           } else if (!this.props.disableOnClickOutside && prevProps.disableOnClickOutside) {
             this.enableOnClickOutside();


### PR DESCRIPTION
This PR addresses the scenario in which the HOC wraps a component that does something like this:

```
const MyMenu = ({ items, asDiv }) => (asDiv? <div>{items}</div> : <ul>{items}</ul>)
```

In that case, if `asDiv` starts as `true` but changes to `false` while the component is rendered, we end up having the click handler listening on the wrong node, and any click inside the `<ul>` is registered as outside.

This PR checks whether the DOM node rendered is the same after each update, and, if not, it updates the handler to the new component.

This also has the advantage of printing warnings if a component switches to returning `null` from its `render()` even though it originally returned a valid DOM element when first rendering.