### PR TITLE
excludeScrollbar can now be set as default for every component instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,16 @@ var Container = React.createClass({
 });
 ``` 
 
+Alternatively, you can specify this behavior as default for all instances of your component passing a configuration object as second parameter:
+
+```js
+var MyComponent = onClickOutside(React.createClass({
+  ...
+}), {
+  excludeScrollbar: true
+});
+``` 
+
 ## Regulating `evt.preventDefault()` and `evt.stopPropagation()`
 
 Technically this HOC lets you pass in `preventDefault={true/false}` and `stopPropagation={true/false}` to regulate what happens to the event when it hits your `handleClickOutside(evt)` function, but beware: `stopPropagation` may not do what you expect it to do.

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@
             instance,
             clickOutsideHandler,
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
-            this.props.excludeScrollbar,
+            this.props.excludeScrollbar, // fallback not needed, prop always exists because of getDefaultProps
             this.props.preventDefault || false,
             this.props.stopPropagation || false
           );

--- a/index.js
+++ b/index.js
@@ -112,6 +112,12 @@
         // this is given meaning in componentDidMount
         __outsideClickHandler: function() {},
 
+        getDefaultProps: function() {
+          return {
+            excludeScrollbar: config && config.excludeScrollbar
+          };
+        },
+
         /**
          * Add click listeners to the current document,
          * linked to this component's state.

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@
             instance,
             clickOutsideHandler,
             this.props.outsideClickIgnoreClass || IGNORE_CLASS,
-            this.props.excludeScrollbar || false,
+            this.props.excludeScrollbar,
             this.props.preventDefault || false,
             this.props.stopPropagation || false
           );


### PR DESCRIPTION
I added the ability to use `excludeScrollbar` for every instance of the wrapper component, using an option in the already existing `config` object that can be passed as second parameter to the `onClickOutside()` wrapper.

This is an opt-in that do not change the current behavior, and that can still be overriden by setting the `excludeScrollbar` prop per-instance as usual.

Implementation is quite neat: I simply used `getDefaultProps()` to set the `excludeScrollbar` prop, so the the feature is still working exactly as it was before.