### PR TITLE
Migrated deprecated React.createClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ $> npm install react-onclickoutside --save
 ```js
 // load the HOC:
 var onClickOutside = require('react-onclickoutside');
+var createReactClass = require('create-react-class');
 
 // create a new component, wrapped by this onclickoutside HOC:
-var MyComponent = onClickOutside(React.createClass({
+var MyComponent = onClickOutside(createReactClass({
   ...,
   handleClickOutside: function(evt) {
     // ...handling code goes here...
@@ -53,9 +54,10 @@ Note that if you try to wrap a React component class without a `handleClickOutsi
 ```js
 // load the HOC:
 var onClickOutside = require('react-onclickoutside');
+var createReactClass = require('create-react-class');
 
 // create a new component, wrapped by this onclickoutside HOC:
-var MyComponent = onClickOutside(React.createClass({
+var MyComponent = onClickOutside(createReactClass({
   ...,
   myClickOutsideHandler: function(evt) {
     // ...handling code goes here...
@@ -189,8 +191,9 @@ In addition, you can create a component that uses this HOC such that it has the 
 
 ```js
 var onClickOutside = require('react-onclickoutside');
+var createReactClass = require('create-react-class');
 
-var MyComponent = onClickOutside(React.createClass({
+var MyComponent = onClickOutside(createReactClass({
   ...,
   handleClickOutside: function(evt) {
     // ...
@@ -198,7 +201,7 @@ var MyComponent = onClickOutside(React.createClass({
   ...
 }));
 
-var Container = React.createClass({
+var Container = createReactClass({
   render: function(evt) {
     return <MyComponent disableOnClickOutside={true} />
   }
@@ -213,27 +216,28 @@ By default this HOC will listen for "clicks inside the document", which may incl
 
 ```js
 var onClickOutside = require('react-onclickoutside');
+var createReactClass = require('create-react-class');
 
-var MyComponent = onClickOutside(React.createClass({
+var MyComponent = onClickOutside(createReactClass({
   ...
 }));
 
-var Container = React.createClass({
+var Container = createReactClass({
   render: function(evt) {
     return <MyComponent excludeScrollbar={true} />
   }
 });
-``` 
+```
 
 Alternatively, you can specify this behavior as default for all instances of your component passing a configuration object as second parameter:
 
 ```js
-var MyComponent = onClickOutside(React.createClass({
+var MyComponent = onClickOutside(createReactClass({
   ...
 }), {
   excludeScrollbar: true
 });
-``` 
+```
 
 ## Regulating `evt.preventDefault()` and `evt.stopPropagation()`
 
@@ -257,8 +261,9 @@ No, I get that. I constantly have that problem myself, so while there is no univ
 
 ```js
 var onClickOutside = require('react-onclickoutside');
+var createReactClass = require('create-react-class');
 
-var MyComponent = onClickOutside(React.createClass({
+var MyComponent = onClickOutside(createReactClass({
   ...,
   handleClickOutside: function(evt) {
     // ...
@@ -266,7 +271,7 @@ var MyComponent = onClickOutside(React.createClass({
   ...
 }));
 
-var Container = React.createClass({
+var Container = createReactClass({
   someFunction: function() {
     var ref = this.refs.mycomp;
     // 1) Get the wrapped component instance:

--- a/index.js
+++ b/index.js
@@ -85,11 +85,11 @@
    * bootstrapping code to yield an instance of the
    * onClickOutsideHOC function defined inside setupHOC().
    */
-  function setupHOC(root, React, ReactDOM) {
+  function setupHOC(root, React, ReactDOM, createReactClass) {
 
     // The actual Component-wrapping HOC:
     return function onClickOutsideHOC(Component, config) {
-      var wrapComponentWithOnClickOutsideHandling = React.createClass({
+      var wrapComponentWithOnClickOutsideHandling = createReactClass({
         statics: {
           /**
            * Access the wrapped Component's class.
@@ -287,17 +287,17 @@
   function setupBinding(root, factory) {
     if (typeof define === 'function' && define.amd) {
       // AMD. Register as an anonymous module.
-      define(['react','react-dom'], function(React, ReactDom) {
-        return factory(root, React, ReactDom);
+      define(['react','react-dom','create-react-class'], function(React, ReactDom, createReactClass) {
+        return factory(root, React, ReactDom, createReactClass);
       });
     } else if (typeof exports === 'object') {
       // Node. Note that this does not work with strict
       // CommonJS, but only CommonJS-like environments
       // that support module.exports
-      module.exports = factory(root, require('react'), require('react-dom'));
+      module.exports = factory(root, require('react'), require('react-dom'), require('create-react-class'));
     } else {
       // Browser globals (root is window)
-      root.onClickOutside = factory(root, React, ReactDOM);
+      root.onClickOutside = factory(root, React, ReactDOM, createReactClass);
     }
   }
 

--- a/test/no-dom-test.js
+++ b/test/no-dom-test.js
@@ -1,11 +1,12 @@
 var assert = require('assert');
 var React = require('react');
+var createReactClass = require('create-react-class');
 var renderer = require('react-test-renderer');
 var requireHijack = require('require-hijack');
 
 describe('onclickoutside hoc with no DOM', function() {
 
-  var Component = React.createClass({    
+  var Component = createReactClass({
 
     handleClickOutside: function() {
     },
@@ -16,7 +17,7 @@ describe('onclickoutside hoc with no DOM', function() {
   });
 
   // tests
-  
+
   it('should not throw an error if rendered in an environment with no DOM', function() {
     // Needed until React 15.4 lands due to https://github.com/facebook/react/issues/7386.
     requireHijack.replace('react-dom').with({

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,11 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var TestUtils = require('react-addons-test-utils');
 var wrapComponent = require('../index');
 
 describe('onclickoutside hoc', function() {
 
-  var Component = React.createClass({
+  var Component = createReactClass({
     getInitialState: function() {
       return {
         clickOutsideHandled: false,
@@ -53,7 +54,7 @@ describe('onclickoutside hoc', function() {
 
 
   it('should throw an error when a component without handleClickOutside(evt) is wrapped', function() {
-    var BadComponent = React.createClass({
+    var BadComponent = createReactClass({
       render: function() {
         return React.createElement('div');
       }
@@ -106,7 +107,7 @@ describe('onclickoutside hoc', function() {
 
 
     it('and createClass method, should call the specified handler when clicking the document', function() {
-      var Component = React.createClass({
+      var Component = createReactClass({
         getInitialState: function() {
           return {
             clickOutsideHandled: false
@@ -170,7 +171,7 @@ describe('onclickoutside hoc', function() {
 
 
     it('and createClass method, should call the specified handler when clicking the document', function() {
-      var Component = React.createClass({
+      var Component = createReactClass({
         render: function() {
           return React.createElement('div');
         }
@@ -223,7 +224,7 @@ describe('onclickoutside hoc', function() {
 
 
   it('should throw an error when a custom handler is specified, but the component does not implement it', function() {
-    var BadComponent = React.createClass({
+    var BadComponent = createReactClass({
       render: function() {
         return React.createElement('div');
       }
@@ -266,7 +267,7 @@ describe('onclickoutside hoc', function() {
 
 
   it('should fallback to call component.props.handleClickOutside when no component.handleClickOutside is defined', function() {
-    var StatelessComponent = React.createClass({
+    var StatelessComponent = createReactClass({
       render: function() {
         return React.createElement('div');
       }
@@ -295,7 +296,7 @@ describe('onclickoutside hoc', function() {
   });
 
   describe('with child rendering as null', function() {
-    var StatelessComponent = React.createClass({
+    var StatelessComponent = createReactClass({
       render: function() {
         return null;
       }


### PR DESCRIPTION
I think we should migrate to the es6 `class` syntax and stop using `React.createClass`, but that would be another step. For now just created this PR, so people stop having deprecation warnings after migration to React v15.5. 

If you feel the same about `class`, I'll create an issue about it, so the matter won't get forgotten and neglected.