### PR TITLE
Add an option to create non-passive event listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ Technically this HOC lets you pass in `preventDefault={true/false}` and `stopPro
 
 Each component adds new event listeners to the document, which may or may not cause as many event triggers as there are event listening bindings. In the test file found in `./test/browser/index.html`, the coded uses `stopPropagation={true}` but sibling events still make it to "parents".
 
+## Handling passive events
+
+Passive event listeners does not block on touch and wheel events because they will not wait to see if `preventDefault()` is called. It allows to have better performance on scrolling ([more details here](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md) and [here](https://developers.google.com/web/updates/2016/06/passive-event-listeners)).
+To explicitely make the created event listeners not passive, allowing us to call `preventDefault` on them, add `{passiveListener: false}` as an option to the HOC.
+
+```js
+export default onClickOutside(Component, { passiveListener: false });
+```
+
 ## Marking elements as "skip over this one" during the event loop
 
 If you want the HOC to ignore certain elements, you can tell the HOC which CSS class name it should use for this purposes. If you want explicit control over the class name, use `outsideClickIgnoreClass={some string}` as component property, or if you don't, the default string used is `ignore-react-onclickoutside`.

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@
         getDefaultProps: function() {
           return {
             excludeScrollbar: config && config.excludeScrollbar,
-            passiveListener: (config && config.passiveListener === false) ? false : true
+            passiveListener: config && config.passiveListener
           };
         },
 
@@ -227,9 +227,17 @@
             if (!events.forEach) {
               events = [events];
             }
-            var options = isPassiveListenerSupported() ? { passive: this.props.passiveListener } : false;
+            var options;
+            if (typeof this.props.passiveListener === 'boolean' && isPassiveListenerSupported()) {
+              options = { passive: this.props.passiveListener };
+            }
             events.forEach(function (eventName) {
-              document.addEventListener(eventName, fn, options);
+              if (options) {
+                document.addEventListener(eventName, fn, options);
+              }
+              else {
+                document.addEventListener(eventName, fn);
+              }
             });
           }
         },

--- a/index.js
+++ b/index.js
@@ -114,7 +114,8 @@
 
         getDefaultProps: function() {
           return {
-            excludeScrollbar: config && config.excludeScrollbar
+            excludeScrollbar: config && config.excludeScrollbar,
+            passiveListener: (config && config.passiveListener === false) ? false : true
           };
         },
 
@@ -226,8 +227,9 @@
             if (!events.forEach) {
               events = [events];
             }
+            var options = isPassiveListenerSupported() ? { passive: this.props.passiveListener } : false;
             events.forEach(function (eventName) {
-              document.addEventListener(eventName, fn);
+              document.addEventListener(eventName, fn, options);
             });
           }
         },
@@ -302,6 +304,26 @@
       root.onClickOutside = factory(root, React, ReactDOM, createReactClass);
     }
   }
+
+  /**
+   * Test via a getter in the options object to see if the passive property is accessed
+   * https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
+   */
+  function isPassiveListenerSupported() {
+    var supportsPassive = false;
+    try {
+      var opts = Object.defineProperty({}, 'passive', {
+        get: function() {
+          supportsPassive = true;
+        }
+      });
+      window.addEventListener('test', null, opts);
+    } catch (e) {
+      return false;
+    }
+    return supportsPassive;
+  }
+
 
   // Make it all happen
   setupBinding(root, setupHOC);


### PR DESCRIPTION
Passive event listeners does not block on `touch` and `wheel` events because they will not wait to see if `preventDefault()` is called. It allows to have better performance on scrolling ([more details here](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md) and [here](https://developers.google.com/web/updates/2016/06/passive-event-listeners)).

All event listeners are now created on passive mode on Chrome [since version 56](https://www.chromestatus.com/features/5093566007214080), and it might be default on other browser in the future.

To explicitely make the created event listeners not passive, allowing us to call `preventDefault` on them, add `{passiveListener: false}` as an option to the HOC.

```js
export default onClickOutside(Component, { passiveListener: false });
```