### PR TITLE
Added preferred module entry to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.0",
   "description": "An onClickOutside wrapper for React components",
   "main": "./index.js",
+  "module": "./index.js",
   "jsnext:main": "./index.js",
   "files": [
     "index.js"


### PR DESCRIPTION
`jsnext:main` is kinda legacy now, and the `module` entry is the preffered one (previous one kept only for compatibility reasons)

I've pushed this only for parity, but keeping those entries is quite obsolete for [those reasons](https://github.com/Pomax/react-onclickoutside/issues/185#issuecomment-304054039)