### PR TITLE
Added prepare script, which can be used by npm5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test:basic": "run-s lint build",
     "test:karma": "karma start test/karma.conf.js --single-run",
     "test:nodom": "mocha test/no-dom-test.js",
-    "precommit": "npm test && lint-staged"
+    "precommit": "npm test && lint-staged",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
this can be used when the package is used as git dependency

In theory now there shouldnt be any problem with this, as `build` is hooked as part of the `precommit`, but anyway I think that's useful if somebody forks and changes something or if `build` stops being part of the `precommit` at some point of the time in the future.