### PR TITLE
allow multiple ignore classes

### DIFF
--- a/src/generateOutsideCheck.js
+++ b/src/generateOutsideCheck.js
@@ -1,4 +1,21 @@
 /**
+ * Check if classList contains any of the given classes,
+ * transparently handling singular and array cases.
+ */
+function containsAny(classList, classes) {
+  if (Array.isArray(classes)) {
+    for (const className of classes) {
+      if (classList.contains(className)) {
+        return true;
+      }
+    }
+    return false;
+  } else {
+    return classList.contains(classes);
+  }
+}
+
+/**
  * Check whether some DOM node is our Component's node.
  */
 function isNodeFound(current, componentNode, ignoreClass) {
@@ -12,9 +29,9 @@ function isNodeFound(current, componentNode, ignoreClass) {
   // See: http://www.w3.org/TR/SVG11/struct.html#InterfaceSVGUseElement
   // Discussion: https://github.com/Pomax/react-onclickoutside/pull/17
   if (current.correspondingElement) {
-    return current.correspondingElement.classList.contains(ignoreClass);
+    return containsAny(current.correspondingElement.classList, ignoreClass);
   }
-  return current.classList.contains(ignoreClass);
+  return containsAny(current.classList, ignoreClass);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
     static defaultProps = {
       eventTypes: ['mousedown', 'touchstart'],
       excludeScrollbar: (config && config.excludeScrollbar) || false,
-      outsideClickIgnoreClass: IGNORE_CLASS_NAME,
+      outsideClickIgnoreClass: (config && config.outsideClickIgnoreClass) || IGNORE_CLASS_NAME,
       preventDefault: false,
       stopPropagation: false,
     };


### PR DESCRIPTION
Only allowing a single ignore class has two issues:
1. Forces you to pollute your entire app with that ignore class. You should be able to declare at the site of the target component all the classes you want to blacklist.
2. In many cases there are plugin architectures where there are elements whose classes you can't control (e.g. popovers) that you still want ignored.
