### PR TITLE
Add config options for all default props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,11 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
     static displayName = `OnClickOutside(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
 
     static defaultProps = {
-      eventTypes: ['mousedown', 'touchstart'],
+      eventTypes: (config && config.eventTypes) || ['mousedown', 'touchstart'],
       excludeScrollbar: (config && config.excludeScrollbar) || false,
-      outsideClickIgnoreClass: IGNORE_CLASS_NAME,
-      preventDefault: false,
-      stopPropagation: false,
+      outsideClickIgnoreClass: (config && config.outsideClickIgnoreClass) || IGNORE_CLASS_NAME,
+      preventDefault: (config && config.preventDefault) || false,
+      stopPropagation: (config && config.stopPropagation) || false,
     };
 
     static getClass = () => (WrappedComponent.getClass ? WrappedComponent.getClass() : WrappedComponent);


### PR DESCRIPTION
Allow excludeScrollbar, preventDefault, outsideClickIgnoreClass and stopPropagation props to be specified in config