### PR TITLE
Simplified core

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:umd:min": "cross-env BABEL_ENV=es NODE_ENV=production rollup -c rollup.umd.config.js -i src/index.js -o dist/react-onclickoutside.min.js",
     "lint": "eslint src/*.js ./test",
     "test": "run-s test:**",
-    "test:basic": "run-s lint build:cjs",
+    "test:basic": "run-s lint build:es",
     "test:karma": "karma start test/karma.conf.js --single-run",
     "test:nodom": "mocha test/no-dom-test.js",
     "precommit": "npm test && lint-staged",

--- a/src/dom-helpers.js
+++ b/src/dom-helpers.js
@@ -1,29 +1,25 @@
 /**
  * Check whether some DOM node is our Component's node.
  */
-export function isNodeFound(current, componentNode, ignoreClass) {
-  if (current === componentNode) {
-    return true;
-  }
+function hasClass(node, ignoreClass) {
   // SVG <use/> elements do not technically reside in the rendered DOM, so
   // they do not have classList directly, but they offer a link to their
   // corresponding element, which can have classList. This extra check is for
   // that case.
   // See: http://www.w3.org/TR/SVG11/struct.html#InterfaceSVGUseElement
   // Discussion: https://github.com/Pomax/react-onclickoutside/pull/17
-  if (current.correspondingElement) {
-    return current.correspondingElement.classList.contains(ignoreClass);
-  }
-  return current.classList.contains(ignoreClass);
+  return (node.correspondingElement || node).classList.contains(ignoreClass);
 }
 
 /**
  * Try to find our node in a hierarchy of nodes, returning the document
  * node as highest node if our node is not found in the path up.
  */
-export function findHighest(current, componentNode, ignoreClass) {
+export function clickedOutsideNodeAndIgnoredSubtree(componentNode, event, ignoreClass) {
+  let current = event.target;
+
   if (current === componentNode) {
-    return true;
+    return false;
   }
 
   // If source=local then this event came from 'somewhere'
@@ -32,17 +28,17 @@ export function findHighest(current, componentNode, ignoreClass) {
   // thinking in terms of Dom node nesting, running counter
   // to React's 'you shouldn't care about the DOM' philosophy.
   while (current.parentNode) {
-    if (isNodeFound(current, componentNode, ignoreClass)) {
-      return true;
+    if (current === componentNode || hasClass(current, ignoreClass)) {
+      return false;
     }
     current = current.parentNode;
   }
-  return current;
+  return true;
 }
 
 /**
  * Check if the browser scrollbar was clicked
  */
-export function clickedScrollbar(evt) {
+export function clickedBrowserScrollbar(evt) {
   return document.documentElement.clientWidth <= evt.clientX || document.documentElement.clientHeight <= evt.clientY;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,13 @@ describe('onclickoutside hoc', function() {
     }
   }
 
-  var WrappedComponent = wrapComponent(Component);
+  var WrappedComponent = wrapComponent(Component, {
+    handleClickOutside(instance) {
+      return function(event) {
+        instance.handleClickOutside(event);
+      };
+    }
+  });
 
   // tests
 


### PR DESCRIPTION
I've simplified the core, removed bunch of possibilities of how the HOC can be used. All of previously covered use cases can be **easily** implemented in the user land. It has benefits of:
- simpler codebase
- smaller codebase
- being actually more configurable

This would make implementing any custom logic easier - including pending PRs with [multiple ignore classes](https://github.com/Pomax/react-onclickoutside/pull/226) and [improved exclude scrollbars logic](https://github.com/Pomax/react-onclickoutside/pull/245). Those both PRs could still get merged in, but in a changed/adjusted form.

I have not yet fixed tests (the probably need complete overhaul and I've wanted to present the idea first) and also introduced naming (`clickedOutsideComparator` and `clickedOutsideNodeAndIgnoredSubtree`) could get more love.

I would also like to propose HOC factory arguments reordering (`function onClickOutsideHOC(config, WrappedComponent)`) so creating reusable factories with prefilled config is easier even with simple `.bind` call.

I am also still unsure why `preventDefault` and `stopPropagation` are implemented in the lib itself instead of letting users to handle that. Could you explain this one? Maybe it would be reasonable to remove those too? I don't have strong opinion on this one, although I have always found that a little bit iffy

How to achieve removed `instance.props.handleClickOutside` feature?
```js
import onClickOutside from 'react-onclickoutside'

onClickOutside(MyComponent, {
	handleClickOutside(instance) {
		return function(event) {
			instance.props.handleClickOutside(event);
		};
	}
})
```

How to achieve removed `instance.handleClickOutside` feature?
```js
import onClickOutside from 'react-onclickoutside'

onClickOutside(MyComponent, {
	handleClickOutside(instance) {
		return function(event) {
			instance.handleClickOutside(event);
		};
	}
})
```

How to achieve removed `excludeScrollbar` feature?
```js
import onClickOutside, { clickedBrowserScrollbar, defaultClickedOutsideComparator } from 'react-onclickoutside'

onClickOutside(MyComponent, {
	clickedOutsideComparator(node, event) {
		if (clickedBrowserScrollbar(event)) return;
		defaultClickedOutsideComparator(node, event)
	},
	handleClickOutside(instance) {
		return someHandler;
	}
})
```

How to achieve removed `outsideClickIgnoreClass` feature?
```js
import onClickOutside, { clickedOutsideNodeAndIgnoredSubtree } from 'react-onclickoutside'

onClickOutside(MyComponent, {
	clickedOutsideComparator(node, event) {
		clickedOutsideNodeAndIgnoredSubtree(node, event, 'ignore-react-onclickoutside')
	},
	handleClickOutside(instance) {
		return someHandler;
	}
})
```