### PR TITLE
Add support for wrapping arrow function component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
      * Access the WrappedComponent's instance.
      */
     getInstance() {
-      if (!WrappedComponent.prototype.isReactComponent) {
+      if (!WrappedComponent.prototype || !WrappedComponent.prototype.isReactComponent) {
         return this;
       }
       const ref = this.instanceRef;
@@ -200,7 +200,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
       // eslint-disable-next-line no-unused-vars
       let { excludeScrollbar, ...props } = this.props;
 
-      if (WrappedComponent.prototype.isReactComponent) {
+      if (WrappedComponent.prototype && WrappedComponent.prototype.isReactComponent) {
         props.ref = this.getRef;
       } else {
         props.wrappedRef = this.getRef;


### PR DESCRIPTION
Right now library will produce error if we try to wrap component that was declared with arrow function (since arrow functions doesn't have prototype property).