### PR TITLE
Use forwardRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "mocha": "^4.0.1",
     "npm-run-all": "^4.0.2",
     "prettier": "^1.8.2",
-    "react": "^15.5.x",
-    "react-dom": "^15.5.x",
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3",
     "react-test-renderer": "^15.5.x",
     "require-hijack": "^1.2.1",
     "rimraf": "^2.6.2",
@@ -77,8 +77,8 @@
     "webpack": "^3.8.1"
   },
   "peerDependencies": {
-    "react": "^15.5.x || ^16.x",
-    "react-dom": "^15.5.x || ^16.x"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "lint-staged": {
     "{src,test}/**/*.js": [


### PR DESCRIPTION
fixes #297 

this doesn't work yet - need to decide what we want to do about function components (they HAVE to be wrapped with `forwardRef` now - wrapped component cant be "just" a function component)

also IMHO ref should be treated as DOM component now - currently the implementation allows it to be a composite component and handles its class methods, this should be IMHO removed - the handler has to be provided in config or in props, not as property of the wrapped component

and we should completely remove `findDOMNode` usage