### PR TITLE
prevents calling findDOMNode on unmounted instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,9 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
     }
 
     componentDidUpdate() {
-      this.componentNode = findDOMNode(this.getInstance());
+      if (this.isMounted) {
+        this.componentNode = findDOMNode(this.getInstance());
+      }
     }
 
     /**


### PR DESCRIPTION
react throws error such as this when findDOMNode is used on an unmounted component instance.
For me this happens when using react-datetime. When user clicks outside the state of our app is mutated and we rerender the view containing the react-datetime and react-onclickoutside components.
