### PR TITLE
Fixed one popover in another in IE11 after unsubscribing events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,12 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
     }
 
     __outsideClickHandler = event => {
+      // If we have one popover in another in IE11, after unsubscribing events
+      // IE calls callback for nested popover while this popover was unsubscribed
+      if (typeof this._isSubscribeEvents === 'boolean' && !this._isSubscribeEvents) {
+        return;
+      }
+
       if (typeof this.__clickOutsideHandlerProp === 'function') {
         this.__clickOutsideHandlerProp(event);
         return;
@@ -171,6 +177,8 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
       events.forEach(eventName => {
         document.addEventListener(eventName, handlersMap[this._uid], getEventHandlerOptions(this, eventName));
       });
+
+      this._isSubscribeEvents = true;
     };
 
     /**
@@ -190,6 +198,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
           document.removeEventListener(eventName, fn, getEventHandlerOptions(this, eventName)),
         );
         delete handlersMap[this._uid];
+        this._isSubscribeEvents = false;
       }
     };
 


### PR DESCRIPTION
If we have one popover in another in IE11, after unsubscribing events IE calls callback for nested popover while this popover was unsubscribed.

So, I have an error `Unable to get property 'getInstance' of undefined or null reference` for this method `_this.getInstance`.

I propose to add variable `_isSubscribeEvents` for class `onClickOutside` which will define subsribe/unsubscribe events in browsers.