### PR TITLE
make it work with shadow dom

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,49 @@ const enabledInstances = {};
 const touchEvents = ['touchstart', 'touchmove'];
 export const IGNORE_CLASS_NAME = 'ignore-react-onclickoutside';
 
+function getDocumentNodes(node) {
+
+  let docs = []
+  while (node.parentNode) {
+    node = node.parentNode
+    
+    if (node.host) {
+      docs.push(node)
+      node = node.host
+    }
+
+  }
+  docs.push(document)
+  return docs
+}
+
+/**
+ * Try to find our node in a hierarchy of nodes, returning the document
+ * node as highest node if our node is not found in the path up.
+ */
+function findHighest(current, componentNode, ignoreClass) {
+  if (current === componentNode) {
+    return true;
+  }
+  // If source=local then this event came from 'somewhere'
+  // inside and should be ignored. We could handle this with
+  // a layered approach, too, but that requires going back to
+  // thinking in terms of Dom node nesting, running counter
+  // to React's 'you shouldn't care about the DOM' philosophy.
+
+
+  while (current.parentNode) {
+    if (isNodeFound(current, componentNode, ignoreClass)) {
+      return true;
+    }
+
+    // walk up to the parentNode, or if we are at a shadow root, continue up via the host element
+    current = current.parentNode || current.host
+  }
+
+  return current;
+}
+
 /**
  * Options for addEventHandler and removeEventHandler
  */
@@ -149,6 +192,9 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
       handlersMap[this._uid] = event => {
         if (this.componentNode === null) return;
 
+          if (event.PROCESSED) return
+          event.PROCESSED = true
+
         if (this.props.preventDefault) {
           event.preventDefault();
         }
@@ -161,7 +207,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
 
         const current = event.target;
 
-        if (DOMHelpers.findHighest(current, this.componentNode, this.props.outsideClickIgnoreClass) !== document) {
+        if (findHighest(current, this.componentNode, this.props.outsideClickIgnoreClass) !== document) {
           return;
         }
 
@@ -169,7 +215,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
       };
 
       events.forEach(eventName => {
-        document.addEventListener(eventName, handlersMap[this._uid], getEventHandlerOptions(this, eventName));
+        getDocumentNodes(this.componentNode).forEach(doc=>doc.addEventListener(eventName, handlersMap[this._uid], getEventHandlerOptions(this, eventName)));
       });
     };
 
@@ -187,7 +233,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
           events = [events];
         }
         events.forEach(eventName =>
-          document.removeEventListener(eventName, fn, getEventHandlerOptions(this, eventName)),
+          getDocumentNodes(this.componentNode).forEach(doc=>doc.removeEventListener(eventName, fn, getEventHandlerOptions(this, eventName)),
         );
         delete handlersMap[this._uid];
       }


### PR DESCRIPTION
This seems to fix shadow dom issues.

The basic issue is that with a dom structure like :

- document
  - body
    - div#shadow-host
      - #shadow-root
         - div#wrapper
           - onClickOutsideDecoratedComponent
             - div#clicker

In the above case the mousedown listener is registered on `document` and when clicking on `div#clicker` the handler is called with an event with target = `div#shadow-host` where as we really want it to start at `div#wrapper`

So the solution is to add the event listeners to both `document` and `#shadow-root` 

However this causes the handler is triggered twice, once with event.target = `div#clicker`, then once with event.target=`div#shadow-host`.  So we tag the event and only handle it once, from `div#clicker`

Then when walking up the dom in findHighest we have to continue via the host element so that we traverse the host document as well