### PR TITLE
Fix to accommodate arrow functions and their lack of a prototype.

### DIFF
--- a/dist/react-onclickoutside.js
+++ b/dist/react-onclickoutside.js
@@ -277,7 +277,7 @@ function onClickOutsideHOC(WrappedComponent, config) {
     var _proto = onClickOutside.prototype;
 
     _proto.getInstance = function getInstance() {
-      if (!WrappedComponent.prototype.isReactComponent) {
+      if (!Object.getPrototypeOf(WrappedComponent).isReactComponent) {
         return this;
       }
 
@@ -339,7 +339,7 @@ function onClickOutsideHOC(WrappedComponent, config) {
           excludeScrollbar = _props.excludeScrollbar,
           props = _objectWithoutProperties(_props, ["excludeScrollbar"]);
 
-      if (WrappedComponent.prototype.isReactComponent) {
+      if (Object.getPrototypeOf(WrappedComponent).isReactComponent) {
         props.ref = this.getRef;
       } else {
         props.wrappedRef = this.getRef;

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
      * Access the WrappedComponent's instance.
      */
     getInstance() {
-      if (!WrappedComponent.prototype.isReactComponent) {
+      if (!Object.getPrototypeOf(WrappedComponent).isReactComponent) {
         return this;
       }
       const ref = this.instanceRef;
@@ -216,7 +216,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
       // eslint-disable-next-line no-unused-vars
       let { excludeScrollbar, ...props } = this.props;
 
-      if (WrappedComponent.prototype.isReactComponent) {
+      if (Object.getPrototypeOf(WrappedComponent).isReactComponent) {
         props.ref = this.getRef;
       } else {
         props.wrappedRef = this.getRef;


### PR DESCRIPTION
While trying to implement testing, I was getting the error:
  - _Cannot read property 'isReactComponent' of undefined_

After some diligent internet scouring, I came across a similar issue on **react-table**, where they came to the conclusion that the lack of a prototype on arrow functions was the root cause and the method that they had in place to normalize, didn't cover that.  @rpalermodrums suggested using _Object.getPrototypeOf_ as a solution. It works for me locally, so fingers crossed. I'm still a little new to software engineering, so I can't say that I'm fully confident that I understand what the potential ramifications are, although it seems pretty straight-forward. Please don't kill me. 