### PR TITLE
Use empty object instead of null as default handlerOptions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,13 @@ export const IGNORE_CLASS_NAME = 'ignore-react-onclickoutside';
  * Options for addEventHandler and removeEventHandler
  */
 function getEventHandlerOptions(instance, eventName) {
-  let handlerOptions = null;
+  const handlerOptions = {};
   const isTouchEvent = touchEvents.indexOf(eventName) !== -1;
 
   if (isTouchEvent && passiveEventSupport) {
-    handlerOptions = { passive: !instance.props.preventDefault };
+    handlerOptions.passive = !instance.props.preventDefault;
   }
+
   return handlerOptions;
 }
 


### PR DESCRIPTION
Hi!

## Motivation
Our team found a conflict between the code of `react-onclickoutside` and the code of some wordpress plugins and themes.
Those plugins use code that makes event listeners passive by default in order to improve scrolling experience, see example by the link - https://stackoverflow.com/a/45974787

This code overwrites `addEventListener` and according to the following lines...
```js
    EventTarget.prototype.addEventListener = function(type, listener, options) {
      var usesListenerOptions = typeof options === 'object';
      var useCapture = usesListenerOptions ? options.capture : options;
```
...there will be an error if `null` is passed as `options`, because `typeof null === 'object'` is true and then `null.capture` leads to a `TypeError: Cannot read property 'capture' of null` error.

And currently there is the case when `react-onclickoutside` passes `null` as `options` to `addEventListener`.
So it leads to the error when our product (with `react-onclickoutside`) is embedded to the user site that has the wordpress plugin.

## Changes
The proposal is to use empty object as default options value instead of null.
It looks like more expected behaviour [according to specs](https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener-type-callback-options-options) and it fixes the conflict.
