### PR TITLE
Compatibility Issues Between "React" and "React-OnClickOutside" Libraries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
     constructor(props) {
       super(props);
       this._uid = uid();
+      this.initTimeStamp = performance.now();
     }
 
     /**
@@ -163,6 +164,8 @@ export default function onClickOutsideHOC(WrappedComponent, config) {
 
       handlersMap[this._uid] = event => {
         if (this.componentNode === null) return;
+        
+        if (this.initTimeStamp > event.timeStamp) return;
 
         if (this.props.preventDefault) {
           event.preventDefault();


### PR DESCRIPTION
Fix for the problem where the event handler was being called even though it was registered after the event was created
[](
https://github.com/Pomax/react-onclickoutside/issues/395)